### PR TITLE
Fix an infinite loop in ExpandAll2[].

### DIFF
--- a/FeynCalc/Shared/SharedTools.m
+++ b/FeynCalc/Shared/SharedTools.m
@@ -403,7 +403,7 @@ ExpandAll2[expr_] :=
 						#
 					],
 				_,
-					expr
+					#
 		] &, expr];
 
 FCAntiSymmetrize[x_,v_List] :=


### PR DESCRIPTION
The default case of the Switch[] call now returns the actual expression
with which it has been called, instead of returning the original "expr".
This makes FixedPoint[] correctly stop instead of possibly looping forever.

A test case:

ExpandAll2[-2 a + 2 b + 2 (a - b)]
