### PR TITLE
Allow `Conjugate` option of ComplexConjugate to have rules

### DIFF
--- a/FeynCalc/Feynman/ComplexConjugate.m
+++ b/FeynCalc/Feynman/ComplexConjugate.m
@@ -187,9 +187,11 @@ ComplexConjugate[expr_/;Head[expr]=!=List, OptionsPattern[]]:=
 			FCPrint[3,"ComplexConjugate: After FCRenameDummyIndices: ", ex, FCDoControl->ccjVerbose]
 		];
 
-		If[	optConjugate=!={} && Head[optConjugate]===List,
-			ruleConjugate= Thread[ru[optConjugate,Conjugate/@optConjugate]]/. ru->Rule;
-			res = res /. ruleConjugate
+		If[optConjugate=!={} && Head[optConjugate]===List,
+			res = res /. (Switch[#,
+				_Rule | _RuleDelayed, #,
+				_, # -> Conjugate[#]
+			] & /@ optConjugate)
 		];
 
 		If[	OptionValue[FCE],


### PR DESCRIPTION
Prior to this, `Conjugate` could only handle a list of elements which must match
exactly for them to be complex conjugated.  This now allows for custom rules to
be allowed.

For example, the following is supported

```
Conjugate -> {
  Lambda,
  y[i_, j_] :> Conjugate[y[i, j]],
  h[i_, j_] :> h[j, i],
  z -> -z
}
```

which will leave the three rules unchanged, and implicitly understand that
`Lambda -> Conjugate[Lambda]`.