### PR TITLE
Add `Flat` attribute to `SmallVariable`

### DIFF
--- a/FeynCalc/Shared/SharedObjects.m
+++ b/FeynCalc/Shared/SharedObjects.m
@@ -1881,6 +1881,8 @@ SISD[0] =
 SISE[0] =
 	0;
 
+SetAttributes[SmallVariable, Flat];
+
 SmallVariable[0] =
 	0;
 


### PR DESCRIPTION
This ensure that `SmallVariable[SmallVariable[x]] == SmallVariable[x]`, which I've had appear a few times in certain calculations.