### PR TITLE
Calculations of loop integral via Feynman parametrization

### DIFF
--- a/FeynCalc/LoopIntegrals/FCFeynmanParameterJoin.m
+++ b/FeynCalc/LoopIntegrals/FCFeynmanParameterJoin.m
@@ -1,0 +1,125 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: FCFeynmanParameterJoin											*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  	Joins propagators using Feyman parametrization				*)
+
+(* ------------------------------------------------------------------------ *)
+
+FCFeynmanParameterJoin::usage =
+"FCFeynmanParameterJoin[int] joins all propagators in int using \
+Feynman parameters but does not integrate over the loop momenta. \
+The function returns {fpInt,pref,vars}, where fpInt is the piece of the \
+integral that contains a single GFAD-type propagator and pref is the \
+part containing the res. The introduced Feynman parameters are listed \
+in vars. The overall Dirac delta is omitted.";
+
+FCFeynmanParameterJoin::failmsg =
+"Error! FCFeynmanParameterJoin has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+Begin["`Package`"]
+End[]
+
+Begin["`FCFeynmanParameterJoin`Private`"]
+
+fcfpjVerbose::usage="";
+overallPref::usage="";
+allVars::usage="";
+allLmoms::usage="";
+optIndexed::usage="";
+optFactoring::usage="";
+optFinalSubstitutions::usage="";
+optDiracDelta::usage="";
+
+Options[FCFeynmanParameterJoin] = {
+	DiracDelta			-> False,
+	FCE					-> False,
+	FCI					-> False,
+	FCVerbose			-> False,
+	Factoring 			-> Factor2,
+	FinalSubstitutions	-> {},
+	Indexed				-> True
+};
+
+
+
+FCFeynmanParameterJoin[exprs_List, lmomsRaw_List /; ! OptionQ[lmomsRaw], OptionsPattern[]]:=
+	Block[{	res, gfad, pref, vars, lmoms, tmp, ex},
+
+		If [OptionValue[FCVerbose]===False,
+			fcfpjVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				fcfpjVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		optIndexed 			  	= OptionValue[Indexed];
+		optFactoring		  	= OptionValue[Factoring];
+		optFinalSubstitutions	= OptionValue[FinalSubstitutions];
+		optDiracDelta			= OptionValue[DiracDelta];
+
+		FCPrint[1,"FCFeynmanParameterJoin: Entering. ", FCDoControl->fcfpjVerbose];
+		FCPrint[3,"FCFeynmanParameterJoin: Entering  with: ", exprs, FCDoControl->fcfpjVerbose];
+
+		If[OptionValue[FCI],
+			ex = exprs,
+			ex = FCI[exprs]
+		];
+
+		overallPref = 1;
+		allVars = {};
+		allLmoms = lmomsRaw;
+
+		tmp = ex //. List[a_, b_, var_] /; Head[a] =!= List && Head[b] =!= List :>
+			feynmanJoin[a, b, var];
+
+		FCPrint[3,"FCFeynmanParameterJoin: After feynmanJoin: ", tmp, FCDoControl->fcfpjVerbose];
+
+
+		res = {tmp, overallPref, Flatten[allVars]};
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1,"FCFeynmanParameterJoin: Leaving.", FCDoControl->fcfpjVerbose];
+		FCPrint[3,"FCFeynmanParameterJoin: Leaving with: ", res, FCDoControl->fcfpjVerbose];
+
+		res
+];
+
+feynmanJoin[a_, b_, var_]:=
+	Block[{gfad,pref,vars,lmoms},
+
+		lmoms = Select[allLmoms, !FreeQ[{a,b},#]&];
+
+		FCPrint[4,"FCFeynmanParameterJoin: feynmanJoin: Entering with: ", {a,b}, FCDoControl->fcfpjVerbose];
+
+		{gfad,pref,vars} = FCSymanzikPolynomials[a b,  lmoms, "FeynmanParameterJoin" -> True,
+				FinalSubstitutions -> optFinalSubstitutions, Indexed->optIndexed,
+				Names -> var, Factoring -> optFactoring];
+
+		FCPrint[4,"FCFeynmanParameterJoin: feynmanJoin: Obtained: ", {gfad,pref,vars}, FCDoControl->fcfpjVerbose];
+
+		If[	optDiracDelta,
+			pref = pref*DiracDelta[1-Total[vars]]
+		];
+
+		overallPref = overallPref pref;
+		allVars 	= Join[allVars,vars];
+		gfad
+	];
+
+
+FCPrint[1,"FCFeynmanParameterJoin.m loaded."];
+End[]

--- a/FeynCalc/LoopIntegrals/FCFeynmanParametrize.m
+++ b/FeynCalc/LoopIntegrals/FCFeynmanParametrize.m
@@ -1,0 +1,196 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: FCFeynmanParametrize											*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  	Returns Feynman parameter integrand of the given loop
+				integral													*)
+
+(* ------------------------------------------------------------------------ *)
+
+FCFeynmanParametrize::usage =
+"FCFeynmanParametrize[int,{q1,q2,...}] introduces Feynman parameters for the \
+scalar multi-loop integral int. Tensor integrals are not supported. The function \
+returns {fpInt,pref,vars}, where fpInt is the integrand without the prefactor, \
+pref is the prefactor free of Feynman parameters and vars is the list of integration \
+variables. The overall Dirac delta in the integrand is omitted unless the option \
+DiracDelta is set to True.";
+
+FCFeynmanParametrize::failmsg =
+"Error! FCFeynmanParametrize has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+Begin["`Package`"]
+End[]
+
+Begin["`FCFeynmanParametrize`Private`"]
+
+dim::usage="";
+fcfpVerbose::usage="";
+null1::usage="";
+null2::usage="";
+isCartesian::usage="";
+
+Options[FCFeynmanParametrize] = {
+	Assumptions				-> {},
+	Dimension				-> D,
+	DiracDelta				-> False,
+	FCE						-> False,
+	FCI						-> False,
+	FCReplaceD				-> {},
+	FCVerbose				-> False,
+	FinalSubstitutions		-> {},
+	Indexed					-> True,
+	Names					-> FCGV["x"],
+	Numerator				-> False,
+	Simplify				-> False,
+	Variables				-> {}
+};
+
+
+FCFeynmanParametrize[expr_, lmoms_List /; ! OptionQ[lmoms], opts:OptionsPattern[]]:=
+	FCFeynmanParametrize[expr, 1, lmoms, opts];
+
+
+FCFeynmanParametrize[expr_, extra_/; Head[extra]=!=List, lmoms_List /; ! OptionQ[lmoms], OptionsPattern[]] :=
+	Block[{	res, optFinalSubstitutions, dim, uPoly, fPoly, pows, mat, powsT,
+			nM,nLoops,fPow,pref,fpInt, fpPref, optFCReplaceD, vars, optVariavbles, aux, ex},
+
+		optFinalSubstitutions	= OptionValue[FinalSubstitutions];
+		dim						= OptionValue[Dimension];
+		optFCReplaceD			= OptionValue[FCReplaceD];
+		optVariavbles			= OptionValue[Variables];
+
+		If [OptionValue[FCVerbose]===False,
+			fcfpVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				fcfpVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		If[OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		Which[
+			!FreeQ[ex,Momentum] && FreeQ[ex,CartesianMomentum],
+			isCartesian=False,
+			(*Lorentzian integral *)
+			FreeQ[ex,Momentum] && !FreeQ[ex,CartesianMomentum],
+			isCartesian=True,
+			(*Cartesian integral *)
+			!FreeQ[ex,Momentum] && !FreeQ[ex,CartesianMomentum],
+			(*Mixed integral*)
+			Message[FCSymanzikPolynomials::failmsg,"Integrals that simultaneously depend on Lorentz and Cartesian vectors are not supported."];
+			Abort[]
+		];
+
+		{uPoly, fPoly, pows, mat} = FCSymanzikPolynomials[ex,lmoms, FCI->True,
+			FinalSubstitutions->OptionValue[FinalSubstitutions], Names->OptionValue[Names], Indexed->OptionValue[Indexed]];
+
+
+		nLoops	= Length[lmoms];
+		powsT 	= Transpose[pows];
+		nM 		= Total[Last[powsT]];
+		fPow 	= nM - nLoops dim/2;
+
+		FCPrint[1,"FCFeynmanParametrize: U: ", uPoly, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: F: ", fPoly, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: pows: ", pows, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: Number of loops: ", nLoops, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: Sum of propagator powers: ", nM, FCDoControl->fcfpVerbose];
+
+		If[!MatchQ[Last[powsT],{(_Integer?Positive| _Symbol)..}] && !OptionValue[Numerator],
+			Message[FCFeynmanParametrize::failmsg,"Numerators are currently not supported."];
+			Abort[]
+		];
+
+		pref = Gamma[fPow]/(Times @@ (Gamma /@ Last[powsT]));
+
+		If[!isCartesian,
+			pref = pref*(-1)^nM
+		];
+
+
+		If[	pref===0 || !Internal`ExceptionFreeQ[pref],
+			Message[FCFeynmanParametrize::failmsg,"Incorrect prefactor."];
+			Abort[]
+		];
+
+		fpPref = (Times @@ Map[Power[#[[1]],(#[[3]]-1)] &, pows]);
+		fpInt =  Power[uPoly,fPow - dim/2]/Power[fPoly,fPow];
+
+		FCPrint[1,"FCFeynmanParametrize: fpPref: ", fpPref, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: pref: ", pref, FCDoControl->fcfpVerbose];
+		FCPrint[1,"FCFeynmanParametrize: raw fpInt: ", fpInt, FCDoControl->fcfpVerbose];
+
+		fpInt = fpInt fpPref;
+
+		If[	uPoly===0 || fPoly===0,
+			fpInt = 0
+		];
+
+		vars = First[powsT];
+
+		(*
+			If there is only a single Feynman parameter, the integration over the Dirac delta
+			is trivial and can be done right away!
+		*)
+		If[	Length[vars]===1,
+			fpInt = fpInt /. vars[[1]] -> 1;
+			vars = {}
+		];
+
+		If[	OptionValue[DiracDelta],
+			fpInt = fpInt*DiracDelta[1-Total[vars]]
+		];
+
+		If[ Length[optVariavbles]=!=0,
+			vars = Join[vars, optVariavbles]
+		];
+
+		aux		= FCProductSplit[extra,vars];
+
+		FCPrint[1,"FCFeynmanParametrize: aux: ", aux, FCDoControl->fcfpVerbose];
+
+		pref	= pref aux[[1]];
+		fpInt	= fpInt aux[[2]];
+
+		FCPrint[1,"FCFeynmanParametrize: fpInt: ", fpInt, FCDoControl->fcfpVerbose];
+
+		If[MatchQ[optFCReplaceD,{_Rule}],
+			fpInt  = FCReplaceD[fpInt,First[optFCReplaceD]];
+			pref = FCReplaceD[pref,First[optFCReplaceD]]
+		];
+
+		If[OptionValue[Simplify],
+			fpInt	= Simplify[fpInt, Assumptions->OptionValue[Assumptions]];
+			pref	= Simplify[pref, Assumptions->OptionValue[Assumptions]]
+		];
+
+
+
+		res = {fpInt,pref,vars};
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1,"FCFeynmanParametrize: Leaving.", FCDoControl->fcfpVerbose];
+		FCPrint[3,"FCFeynmanParametrize: Leaving with: ", res, FCDoControl->fcfpVerbose];
+
+		res
+];
+
+
+FCPrint[1,"FCFeynmanParametrize.m loaded."];
+End[]

--- a/FeynCalc/LoopIntegrals/FCSymanzikPolynomials.m
+++ b/FeynCalc/LoopIntegrals/FCSymanzikPolynomials.m
@@ -1,0 +1,289 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: FCSymanzikPolynomials											*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  	Calculates Symanzik polynomials U and V for the given loop
+				integral													*)
+
+(* ------------------------------------------------------------------------ *)
+
+FCSymanzikPolynomials::usage =
+"FCSymanzikPolynomials[int,{q1,q2,...}] returns {U,F,P,M}, \
+where U and F are the Symanzik polynomials, with U = det M, while \
+P shows the powers of the occurring propagators. Notice that int \
+can be a single loop integral or a list of propagators. \n
+The algorithm for deriving the UF-parametrization of a loop integral \
+was adopted from the UF generator available in multiple codes of \
+Alexander Smirnov, such as FIESTA (arXiv:1511.03614) and FIRE \
+(arXiv:1901.07808). The code UF.m was also mentioned in the book \
+\"Analytic Tools for Feynman Integrals\" by Vladimir Smirnov, Chapter 2.3";
+
+FCSymanzikPolynomials::failmsg =
+"Error! FCSymanzikPolynomials has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+Begin["`Package`"]
+End[]
+
+Begin["`FCSymanzikPolynomials`Private`"]
+
+dim::usage="";
+fcszVerbose::usage="";
+null1::usage="";
+null2::usage="";
+isCartesian::usage="";
+
+Options[FCSymanzikPolynomials] = {
+	FCE						-> False,
+	FCI						-> False,
+	FCVerbose				-> False,
+	Factoring 				-> Factor2,
+	FinalSubstitutions		-> {},
+	Indexed					-> True,
+	Names					-> FCGV["x"],
+	Reduce					-> False,
+	"FeynmanParameterJoin"	-> False
+};
+
+
+FCSymanzikPolynomials[expr_, lmoms_List /; ! OptionQ[lmoms], OptionsPattern[]] :=
+	Block[{	feynX, propProduct, tmp, symF, symU, ex, spd, mtmp,
+			matrix, nDenoms, res, constraint, tmp0, powers, optFactoring,
+			optFinalSubstitutions, optNames, aux1, aux2, nProps},
+
+		optNames				= OptionValue[Names];
+		optFactoring 			= OptionValue[Factoring];
+		optFinalSubstitutions	= OptionValue[FinalSubstitutions];
+
+		If [OptionValue[FCVerbose]===False,
+			fcszVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				fcszVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		If[OptionValue[FCI],
+			ex = expr,
+			{ex,optFinalSubstitutions} = FCI[{expr,optFinalSubstitutions}]
+		];
+
+		If [!FreeQ2[$ScalarProducts, {lmoms}],
+			Message[FCSymanzikPolynomials::failmsg, "Some of the loop momenta have scalar product rules attached to them."];
+			Abort[]
+		];
+
+		If[	!MatchQ[ex,{__}|_. _FeynAmpDenominator],
+			Message[FCSymanzikPolynomials::failmsg, "The input expression is not a proper integral or list of propagators"];
+			Abort[]
+
+		];
+
+		FCPrint[1,"FCSymanzikPolynomials: Entering. ", FCDoControl->fcszVerbose];
+		FCPrint[3,"FCSymanzikPolynomials: Entering  with: ", ex, FCDoControl->fcszVerbose];
+
+		Which[
+			!FreeQ[ex,Momentum] && FreeQ[ex,CartesianMomentum],
+			isCartesian=False,
+			(*Lorentzian integral *)
+			FreeQ[ex,Momentum] && !FreeQ[ex,CartesianMomentum],
+			isCartesian=True,
+			(*Cartesian integral *)
+			!FreeQ[ex,Momentum] && !FreeQ[ex,CartesianMomentum],
+			(*Mixed integral*)
+			Message[FCSymanzikPolynomials::failmsg,"Integrals that simultaneously depend on Lorentz and Cartesian vectors are not supported."];
+			Abort[]
+		];
+
+		dim = FCGetDimensions[ex];
+
+		If[	Length[dim]=!=1,
+			Message[FCSymanzikPolynomials::failmsg,"The loop integrals contains momenta in different dimensions."];
+			Abort[]
+		];
+		dim = First[dim];
+
+		If[	Union[FreeQ[ex,#]&/@lmoms]=!={False},
+			Message[FCSymanzikPolynomials::failmsg,"Some of the specified loop momenta are not contained in the input expression."];
+			Abort[]
+		];
+
+
+		tmp = FCLoopBasisExtract[ex, lmoms, SetDimensions->{dim}];
+
+
+		FCPrint[3,"FCSymanzikPolynomials: List of denominators: ", tmp, FCDoControl->fcszVerbose];
+
+
+		nDenoms = Length[tmp[[1]]];
+		feynX 	= Table[optNames[i],{i,1,nDenoms}];
+
+		If[	!OptionValue[Indexed],
+			feynX = feynX /. s_Symbol[i_Integer] :> ToExpression[ToString[s]<>ToString[i]]
+		];
+
+		powers 	= Table[{feynX[[i]],tmp[[4]][[i]],tmp[[3]][[i]]},{i,1,nDenoms}];
+		tmp = Sum[feynX[[i]] tmp[[1]][[i]],{i,1,nDenoms}];
+
+
+		FCPrint[3,"FCSymanzikPolynomials: Powers of denominators: ", powers, FCDoControl->fcszVerbose];
+
+		FCPrint[3,"FCSymanzikPolynomials: After introducing the Feynman paramters: ", tmp, FCDoControl->fcszVerbose];
+
+
+		If[	OptionValue["FeynmanParameterJoin"]===True,
+			aux1 = (Times @@ Map[Power[#[[1]],(#[[3]]-1)] &, powers]);
+			aux2 = Last[Transpose[powers]];
+			aux1 = aux1*Gamma[Total[aux2]]/(Times@@(Gamma/@aux2));
+			res = {FeynAmpDenominator[GenericPropagatorDenominator[tmp, {Total[aux2], 1}]], aux1, feynX};
+			Return[res]
+		];
+
+		If[ !isCartesian,
+
+			tmp0 = tmp //. {
+				Pair[Momentum[a_, dim], Momentum[b_, dim]] /; MemberQ[lmoms, a] && MemberQ[lmoms, b] :> spd[a, b]
+			},
+
+			tmp0 = tmp //. {
+				CartesianPair[CartesianMomentum[a_, dim], CartesianMomentum[b_, dim]] /; MemberQ[lmoms, a] && MemberQ[lmoms, b] :> spd[a, b]
+			}
+		];
+
+		(* symmetrization, otherwise the M-matrix will not come out right! *)
+		tmp0 = tmp0 /. spd[a_,b_]:> 1/2 (spd[a,b] + spd[b,a]);
+
+		FCPrint[3,"FCSymanzikPolynomials: tmp0: ", tmp0, FCDoControl->fcszVerbose];
+
+		mtmp = SelectNotFree2[tmp0 + null1 + null2, spd];
+
+		FCPrint[3,"FCSymanzikPolynomials: mtmp: ", mtmp, FCDoControl->fcszVerbose];
+
+		matrix = (Outer[spd, lmoms, lmoms] /. a_spd :> Coefficient[mtmp, a]);
+		FCPrint[3,"FCSymanzikPolynomials: M: ", matrix, FCDoControl->fcszVerbose];
+
+
+		{symU, symF} = Fold[buildF, {1, tmp}, lmoms];
+
+		FCPrint[3,"FCSymanzikPolynomials: Raw U: ", symU, FCDoControl->fcszVerbose];
+		FCPrint[3,"FCSymanzikPolynomials: Raw F: ", symF, FCDoControl->fcszVerbose];
+
+		If[	Simplify[Det[matrix]-symU]=!=0 || !SymmetricMatrixQ[matrix],
+			Message[FCSymanzikPolynomials::failmsg,"Something went wrong when calculating the matrix M!"];
+
+		];
+
+
+		If[ !isCartesian,
+			(*The extra minus sign in symF comes from pulling out (-1)^N in the Minkowski case *)
+			res = {symU, -Together[symU symF], powers, matrix},
+			res = {symU, Together[symU symF], powers, matrix};
+		];
+
+		FCPrint[3,"FCSymanzikPolynomials: Preliminary result: ", res, FCDoControl->fcszVerbose];
+
+		If[	optFinalSubstitutions=!={},
+			res = res /. optFinalSubstitutions
+		];
+
+
+		If[	optFactoring=!=False,
+			res = optFactoring[res];
+			FCPrint[3,"FCSymanzikPolynomials: After applying Simplify to the result: ", res, FCDoControl->fcszVerbose];
+		];
+
+		If[	nDenoms>1 && OptionValue[Reduce],
+
+			constraint = (Sum[feynX[[i]],{i,1,nDenoms}]==1);
+
+			FCPrint[3,"FCSymanzikPolynomials: Constraint on the values of the Feynman parameters: ", constraint, FCDoControl->fcszVerbose];
+
+			res = Simplify[res,constraint]
+		];
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1,"FCSymanzikPolynomials: Leaving.", FCDoControl->fcszVerbose];
+		FCPrint[3,"FCSymanzikPolynomials: Leaving with: ", res, FCDoControl->fcszVerbose];
+
+		res
+];
+
+buildF[{oldSymU_, oldSymF_}, lmom_] :=
+	Block[{tmp, lmsq, lambda, J, num, res},
+
+		tmp = ExpandScalarProduct[oldSymF, Momentum -> lmom, FCI -> True];
+
+
+		If[ !isCartesian,
+			(*The extra minus sign in symF comes from pulling out (-1)^N *)
+			tmp = tmp /. Pair[Momentum[lmom, dim], Momentum[lmom, dim]] :> lmsq,
+			tmp = tmp /. CartesianPair[CartesianMomentum[lmom, dim], CartesianMomentum[lmom, dim]] :> lmsq
+		];
+
+
+
+		FCPrint[3,"FCSymanzikPolynomials: buildF: tmp: ", tmp, FCDoControl->fcszVerbose];
+		FCPrint[3,"FCSymanzikPolynomials: buildF: Current loop momentum: ", lmom, FCDoControl->fcszVerbose];
+
+		lambda = Coefficient[tmp, lmsq];
+
+		If[	lambda===0,
+			Message[FCSymanzikPolynomials::failmsg,"The coefficient of one of the loop momenta squared is zero."];
+			Abort[]
+		];
+
+		tmp = Expand2[tmp, {Pair, CartesianPair, lmom}];
+
+		If[ !isCartesian,
+		tmp = tmp //.
+			{a_. Pair[Momentum[lmom, dim], x_] + b_. Pair[Momentum[lmom, dim], y_] /; FreeQ[{x, y}, lmom] :>
+				Pair[Momentum[lmom, dim], a x + b y]} /.
+			{Pair[Momentum[lmom, dim], Momentum[lmom, dim]] :> lmsq},
+
+		tmp = tmp //.
+			{a_. CartesianPair[CartesianMomentum[lmom, dim], x_] + b_. CartesianPair[CartesianMomentum[lmom, dim], y_] /; FreeQ[{x, y}, lmom] :>
+				CartesianPair[CartesianMomentum[lmom, dim], a x + b y]} /.
+			{CartesianPair[CartesianMomentum[lmom, dim], CartesianMomentum[lmom, dim]] :> lmsq}
+
+		];
+
+		FCPrint[3,"FCSymanzikPolynomials: buildF: tmp after combinging the scalar products: ", tmp, FCDoControl->fcszVerbose];
+
+		num = (SelectNotFree2[tmp + null1 + null2, lmom])^2 /. null1 | null2 -> 0;
+
+		If[ !isCartesian,
+			num = num /. Pair[Momentum[lmom, ___], y_]^2 /; FreeQ[y, lmom] :> ExpandScalarProduct[Pair[y, y], FCI -> True],
+			num = num /. CartesianPair[CartesianMomentum[lmom, ___], y_]^2 /; FreeQ[y, lmom] :> ExpandScalarProduct[CartesianPair[y, y], FCI -> True]
+		];
+
+
+		J = SelectFree2[tmp + null1 + null2, {lmom, lmsq}] /. null1 | null2 -> 0;
+
+		FCPrint[3,"FCSymanzikPolynomials: buildF: J: ", J, FCDoControl->fcszVerbose];
+
+		res = J - num/(4 lambda);
+
+		FCPrint[3,"FCSymanzikPolynomials: buildF: res: ", res, FCDoControl->fcszVerbose];
+
+		If[	!FreeQ2[res,{lmsq,lmom}],
+			Message[FCSymanzikPolynomials::failmsg,"buildF failed to eliminate one of the loop momenta."];
+			Abort[]
+		];
+
+		{oldSymU lambda, J - num/(4 lambda)}
+];
+
+
+FCPrint[1,"FCSymanzikPolynomials.m loaded."];
+End[]

--- a/Tests/LoopIntegrals/FCFeynmanParameterJoin.test
+++ b/Tests/LoopIntegrals/FCFeynmanParameterJoin.test
@@ -1,0 +1,48 @@
+
+
+(* :Title: FCFeynmanParameterJoin.test										*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for FCFeynmanParameterJoin	*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`LoopIntegrals`fcstFCFeynmanParameterJoin =
+({
+{"fcstFCFeynmanParameterJoin-ID1",
+"FCFeynmanParameterJoin[{SFAD[{p1,mb^2}],SFAD[p1-p3],x},{p1},\
+DiracDelta\[Rule]True]",
+"{FeynAmpDenominator[GenericPropagatorDenominator[(-mb^2 + \
+Pair[Momentum[p1, D], Momentum[p1, D]])*x[1] + (Pair[Momentum[p1, D], \
+Momentum[p1, D]] - 2*Pair[Momentum[p1, D], Momentum[p3, D]] + \
+Pair[Momentum[p3, D], Momentum[p3, D]])*x[2], {2, 1}]], DiracDelta[-1 \
++ x[1] + x[2]], {x[1], x[2]}}"},
+{"fcstFCFeynmanParameterJoin-ID2",
+"FCFeynmanParameterJoin[{{SFAD[{p1,mb^2}],SFAD[p1-p3],x},SFAD[{p3,\
+mb^2}],y},{p1,p3}]",
+"{FeynAmpDenominator[GenericPropagatorDenominator[(-(mb^2*x[1]) + \
+Pair[Momentum[p1, D], Momentum[p1, D]]*x[1] + Pair[Momentum[p1, D], \
+Momentum[p1, D]]*x[2] - 2*Pair[Momentum[p1, D], Momentum[p3, D]]*x[2] \
++ Pair[Momentum[p3, D], Momentum[p3, D]]*x[2])*y[1] + (-mb^2 + \
+Pair[Momentum[p3, D], Momentum[p3, D]])*y[2], {3, 1}]], 2*y[1], \
+{x[1], x[2], y[1], y[2]}}"},
+{"fcstFCFeynmanParameterJoin-ID3",
+"FCFeynmanParameterJoin[{{{SFAD[{p1,mb^2}],SFAD[p1-p3],x},SFAD[{p3,\
+mb^2}],y},SFAD[{{0,p1.q}}],z},{p1,p3},Indexed\[Rule]False,DiracDelta\
+\[Rule]True]",
+"{FeynAmpDenominator[GenericPropagatorDenominator[z2*Pair[Momentum[\
+p1, D], Momentum[q, D]] + z1*(-(mb^2*x1*y1) - mb^2*y2 + \
+x1*y1*Pair[Momentum[p1, D], Momentum[p1, D]] + \
+x2*y1*Pair[Momentum[p1, D], Momentum[p1, D]] - \
+2*x2*y1*Pair[Momentum[p1, D], Momentum[p3, D]] + \
+x2*y1*Pair[Momentum[p3, D], Momentum[p3, D]] + y2*Pair[Momentum[p3, \
+D], Momentum[p3, D]]), {4, 1}]], 6*y1*z1^2*DiracDelta[-1 + x1 + \
+x2]*DiracDelta[-1 + y1 + y2]*DiracDelta[-1 + z1 + z2], {x1, x2, y1, \
+y2, z1, z2}}"}
+});

--- a/Tests/LoopIntegrals/FCFeynmanParametrize.test
+++ b/Tests/LoopIntegrals/FCFeynmanParametrize.test
@@ -1,0 +1,58 @@
+
+
+(* :Title: FCFeynmanParametrize.test										*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for FCFeynmanParametrize		*)
+
+(* ------------------------------------------------------------------------ *)
+
+
+Tests`LoopIntegrals`fcstFCFeynmanParametrize =
+({
+{"fcstFCFeynmanParametrize-ID1",
+"FCFeynmanParametrize[SFAD[{p,0,n}],{p},Names\[Rule]x,Indexed\
+\[Rule]False,Simplify\[Rule]True]",
+"{0, ((-1)^n*Gamma[-D/2 + n])/Gamma[n], {}}"},
+{"fcstFCFeynmanParametrize-ID2",
+"FCFeynmanParametrize[SFAD[{p,m^2}],{p},Names\[Rule]x,Indexed\
+\[Rule]False,Simplify\[Rule]True]",
+"{(m^2)^(-1 + D/2), -Gamma[1 - D/2], {}}"},
+{"fcstFCFeynmanParametrize-ID3",
+"FCFeynmanParametrize[SFAD[{p,m^2,n}],{p},Names\[Rule]x,Indexed\
+\[Rule]False,Simplify\[Rule]True]",
+"{(m^2)^((D - 2*n)/2), ((-1)^n*Gamma[-D/2 + n])/Gamma[n], {}}"},
+{"fcstFCFeynmanParametrize-ID4",
+"FCFeynmanParametrize[SFAD[{p,0,1},{p+q,0,1}],{p},Names\[Rule]x,\
+FCReplaceD\[Rule]{D->4-2ep},FCE\[Rule]True,Names\[Rule]x,Indexed\
+\[Rule]False]",
+"{(x1 + x2)^(-2 + 2*ep)*(-(x1*x2*SPD[q, q]))^(-2 + (4 - 2*ep)/2), \
+Gamma[2 + (-4 + 2*ep)/2], {x1, x2}}"},
+{"fcstFCFeynmanParametrize-ID5",
+"FCFeynmanParametrize[SFAD[{p,0,n1},{p+q,0,n2}],{p},Names\[Rule]x,\
+FCReplaceD\[Rule]{D->4-2ep},FCE\[Rule]True,Names\[Rule]x,Indexed\
+\[Rule]False]",
+"{x1^(-1 + n1)*x2^(-1 + n2)*(x1 + x2)^(-4 + 2*ep + n1 + \
+n2)*(-(x1*x2*SPD[q, q]))^((4 - 2*ep)/2 - n1 - n2), ((-1)^(n1 + \
+n2)*Gamma[(-4 + 2*ep)/2 + n1 + n2])/(Gamma[n1]*Gamma[n2]), {x1, x2}}"},
+{"fcstFCFeynmanParametrize-ID6",
+"FCFeynmanParametrize[SFAD[{p1,mb^2},p3,p1+q,{p3+q,mb^2},{p1-p3,mb^\
+2}],{p1,p3},Names\[Rule]x,Indexed\[Rule]False,Simplify\[Rule]True,\
+FinalSubstitutions\[Rule]{FCI[SPD[q]]\[Rule]mb^2}]",
+"{(x4*(x3 + x5) + x1*(x2 + x3 + x5) + x2*(x3 + x4 + x5))^(5 - \
+(3*D)/2)*(mb^2*(x4*x5^2 + x1^2*(x2 + x3 + x5) + x2^2*(x3 + x4 + x5) + \
+x2*x5*(2*x4 + x5) + x1*(x2^2 + x5^2 + 2*x2*(x3 + x5))))^(-5 + D), \
+-Gamma[5 - D], {x1, x2, x3, x4, x5}}"},
+{"fcstFCFeynmanParametrize-ID7",
+"FCFeynmanParametrize[SFAD[p3,{p1+q,mb^2},p1-p3],{p1,p3},Names\
+\[Rule]x,Indexed\[Rule]False,Simplify\[Rule]True,FinalSubstitutions\
+\[Rule]{FCI[SPD[q]]\[Rule]mb^2},FCReplaceD\[Rule]{D->4-2Epsilon}]",
+"{(mb^2*(x1 + x2)*x3^2)^(1 - 2*Epsilon)*(x2*x3 + x1*(x2 + \
+x3))^(3*(-1 + Epsilon)), -Gamma[-1 + 2*Epsilon], {x1, x2, x3}}"}
+});

--- a/Tests/LoopIntegrals/FCSymanzikPolynomials.test
+++ b/Tests/LoopIntegrals/FCSymanzikPolynomials.test
@@ -1,0 +1,227 @@
+
+
+(* :Title: FCSymanzikPolynomials.test										*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for FCSymanzikPolynomials	*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`LoopIntegrals`fcstFCSymanzikPolynomials =
+({
+{"fcstFCSymanzikPolynomials-ID1",
+"FCSymanzikPolynomials[FAD[{q1,0}],{q1},Names\[Rule]x,FCE->True]",
+"{x[1], 0, {{x[1], FAD[q1], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID2",
+"FCSymanzikPolynomials[FAD[{q1,m1}],{q1},Names\[Rule]x,FCE->True]",
+	"{x[1], m1^2*x[1]^2, {{x[1], FAD[{q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID3",
+"FCSymanzikPolynomials[FAD[{q1+p1,m1}],{q1},Names\[Rule]x,\
+FCE->True]",
+"{x[1], m1^2*x[1]^2, {{x[1], FAD[{p1 + q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID4",
+"FCSymanzikPolynomials[FAD[{q1+2p1,m1}],{q1},Names\[Rule]x,\
+FCE->True]",
+"{x[1], m1^2*x[1]^2, {{x[1], FAD[{2*p1 + q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID5",
+"FCSymanzikPolynomials[FAD[{q1+n \
+p1,m1}],{q1},Names\[Rule]x,FCE->True]",
+"{x[1], m1^2*x[1]^2, {{x[1], FAD[{n*p1 + q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID6",
+"FCSymanzikPolynomials[FAD[{q1,m1},{q1,m2}],{q1},Names\[Rule]x,\
+FCE->True]",
+"{x[1] + x[2], (x[1] + x[2])*(m1^2*x[1] + m2^2*x[2]), {{x[1], \
+FAD[{q1, m1}], 1}, {x[2], FAD[{q1, m2}], 1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID7",
+"FCSymanzikPolynomials[FAD[{q1,m1},{q1}],{q1},Names\[Rule]x,\
+FCE->True]",
+"{x[1] + x[2],
+m1^2*x[2]*(x[1] + x[2]), {{x[1], FAD[q1], 1}, {x[2], FAD[{q1, m1}],
+1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID8",
+"FCSymanzikPolynomials[FAD[{q1},{q1,m2}],{q1},Names\[Rule]x,\
+FCE->True]",
+"{x[1] + x[2], m2^2*x[2]*(x[1] + x[2]), {{x[1], FAD[q1], 1}, \
+{x[2], FAD[{q1, m2}], 1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID9",
+"FCSymanzikPolynomials[FAD[{q1+p1,m1},{q1+p2,m2}],{q1},Names\[Rule]\
+x,FCE->True]",
+"{x[1] + x[2], m1^2*x[1]^2 + m1^2*x[1]*x[2] + m2^2*x[1]*x[2] - \
+SPD[p1, p1]*x[1]*x[2] + 2*SPD[p1, p2]*x[1]*x[2] - SPD[p2, \
+p2]*x[1]*x[2] + m2^2*x[2]^2, {{x[1], FAD[{p1 + q1, m1}], 1}, {x[2], \
+FAD[{p2 + q1, m2}], 1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID10",
+"FCSymanzikPolynomials[FAD[{q1,m1},{q1-p1+p2,m2}],{q1},Names\[Rule]\
+x,FCE->True]",
+"{x[1] + x[2], m1^2*x[1]^2 + m1^2*x[1]*x[2] + m2^2*x[1]*x[2] - \
+SPD[p1, p1]*x[1]*x[2] + 2*SPD[p1, p2]*x[1]*x[2] - SPD[p2, \
+p2]*x[1]*x[2] + m2^2*x[2]^2, {{x[1], FAD[{q1, m1}], 1}, {x[2], \
+FAD[{-p1 + p2 + q1, m2}], 1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID11",
+"FCSymanzikPolynomials[SPD[q1,p1]FAD[{q1,m1},{q1-p1+p2,m2}],{q1},\
+Names\[Rule]x,Reduce\[Rule]True,FCE->True]",
+"{x[2] + x[3], m1^2*x[2]^2 + (m1^2 + m2^2 - SPD[p2, p2])*x[2]*x[3] \
++ SPD[p1, p2]*(1 + x[2] - x[3])*x[3] + m2^2*x[3]^2 + (SPD[p1, \
+p1]*(x[1]^2 - 4*x[1]*x[3] - 4*x[2]*x[3]))/4, {{x[1], SPD[p1, q1], \
+-1}, {x[2], FAD[{q1, m1}], 1}, {x[3], FAD[{-p1 + p2 + q1, m2}], 1}}, \
+{{x[2] + x[3]}}}"},
+{"fcstFCSymanzikPolynomials-ID12",
+"FCSymanzikPolynomials[SPD[q1,p1]FAD[{q1,m1},{q1-p1+p2,m2}],{q1},\
+Names\[Rule]x,Reduce\[Rule]False,FCE->True]",
+"{x[2] + x[3], (SPD[p1, p1]*x[1]^2 + 4*m1^2*x[2]^2 - 4*SPD[p1, \
+p1]*x[1]*x[3] + 4*SPD[p1, p2]*x[1]*x[3] + 4*m1^2*x[2]*x[3] + \
+4*m2^2*x[2]*x[3] - 4*SPD[p1, p1]*x[2]*x[3] + 8*SPD[p1, p2]*x[2]*x[3] \
+- 4*SPD[p2, p2]*x[2]*x[3] + 4*m2^2*x[3]^2)/4, {{x[1], SPD[p1, q1], \
+-1}, {x[2], FAD[{q1, m1}], 1}, {x[3], FAD[{-p1 + p2 + q1, m2}], 1}}, \
+{{x[2] + x[3]}}}"},
+{"fcstFCSymanzikPolynomials-ID13",
+"FCSymanzikPolynomials[FAD[{q1,m1},{q1-p1+p2,m2}],{q1},Names\[Rule]\
+x,Reduce\[Rule]True,FCE->True]",
+"{1, m1^2 - (m1^2 - m2^2 + SPD[p2, p2])*x[2] + SPD[p1, p1]*(-1 + \
+x[2])*x[2] - 2*SPD[p1, p2]*(-1 + x[2])*x[2] + SPD[p2, p2]*x[2]^2, \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[{-p1 + p2 + q1, m2}], 1}}, \
+{{1}}}"},
+{"fcstFCSymanzikPolynomials-ID14",
+"FCSymanzikPolynomials[FAD[{q1,m1},{q1-p1+p2,m2}],{q1},Names\[Rule]\
+x,Reduce\[Rule]True,FCE->True]",
+"{1, m1^2 - (m1^2 - m2^2 + SPD[p2, p2])*x[2] + SPD[p1, p1]*(-1 + \
+x[2])*x[2] - 2*SPD[p1, p2]*(-1 + x[2])*x[2] + SPD[p2, p2]*x[2]^2, \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[{-p1 + p2 + q1, m2}], 1}}, \
+{{1}}}"},
+{"fcstFCSymanzikPolynomials-ID15",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2},{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], GFAD[{{-m1^2 + SPD[q1, q1], 1}, \
+-1}], -1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID16",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2,SPD[p1,q1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1], (4*m1^2*x[1]^2 + SPD[p1, p1]*x[2]^2)/4, {{x[1], \
+GFAD[{{-m1^2 + SPD[q1, q1], 1}, -1}], -1}, {x[2], SPD[p1, q1], -1}}, \
+{{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID17",
+"FCSymanzikPolynomials[{FAD[{q1,m1}]},{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], FAD[{q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID18",
+"FCSymanzikPolynomials[FAD[{q1,m1}],{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], FAD[{q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID19",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2,SPD[q1-p1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], GFAD[{{-m1^2 + SPD[q1, q1], 1}, -1}], -1}, {x[2], SPD[p1, p1] \
+- 2*SPD[p1, q1] + SPD[q1, q1], -1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID20",
+"FCSymanzikPolynomials[{FAD[{q1,m1}],FAD[q1-p1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[-p1 + q1], 1}}, {{x[1] + \
+x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID21",
+"FCSymanzikPolynomials[FAD[{q1,m1}]FAD[q1-p1],{q1},Names\[Rule]x,\
+FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[-p1 + q1], 1}}, {{x[1] + \
+x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID22",
+"FCSymanzikPolynomials[FAD[{p1,m},p1+q1,p3,p1-p3],{p1,p3},Names\
+\[Rule]x,FCE\[Rule]True]",
+"{x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[2]*x[4] + x[3]*x[4], m^2*x[1]^2*x[2] +
+m^2*x[1]^2*x[3] + m^2*x[1]*x[2]*x[3] + m^2*x[1]*x[2]*x[4] - SPD[q1, q1]*x[1]*x[2]*x[4] +
+m^2*x[1]*x[3]*x[4] - SPD[q1, q1]*x[1]*x[3]*x[4] - SPD[q1, q1]*x[2]*x[3]*x[4], {{x[1],
+FAD[{p1, m}], 1}, {x[2], FAD[p1 - p3], 1}, {x[3], FAD[p3], 1}, {x[4], FAD[p1 + q1],
+1}}, {{x[1] + x[2] + x[4], -x[2]}, {-x[2], x[2] + x[3]}}}"},
+{"fcstFCSymanzikPolynomials-ID23",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2},{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], GFAD[{{-m1^2 + SPD[q1, q1], 1}, \
+-1}], -1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID24",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2,SPD[p1,q1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1], (4*m1^2*x[1]^2 + SPD[p1, p1]*x[2]^2)/4, {{x[1], \
+GFAD[{{-m1^2 + SPD[q1, q1], 1}, -1}], -1}, {x[2], SPD[p1, q1], -1}}, \
+{{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID25",
+"FCSymanzikPolynomials[{FAD[{q1,m1}]},{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], FAD[{q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID26",
+"FCSymanzikPolynomials[FAD[{q1,m1}],{q1},Names\[Rule]x,FCE\[Rule]\
+True]", "{x[1], m1^2*x[1]^2, {{x[1], FAD[{q1, m1}], 1}}, {{x[1]}}}"},
+{"fcstFCSymanzikPolynomials-ID27",
+"FCSymanzikPolynomials[{SPD[q1]-m1^2,SPD[q1-p1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], GFAD[{{-m1^2 + SPD[q1, q1], 1}, -1}], -1}, {x[2], SPD[p1, p1] \
+- 2*SPD[p1, q1] + SPD[q1, q1], -1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID28",
+"FCSymanzikPolynomials[{FAD[{q1,m1}],FAD[q1-p1]},{q1},Names\[Rule]\
+x,FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[-p1 + q1], 1}}, {{x[1] + \
+x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID29",
+"FCSymanzikPolynomials[FAD[{q1,m1}]FAD[q1-p1],{q1},Names\[Rule]x,\
+FCE\[Rule]True]",
+"{x[1] + x[2], x[1]*(m1^2*x[1] + m1^2*x[2] - SPD[p1, p1]*x[2]), \
+{{x[1], FAD[{q1, m1}], 1}, {x[2], FAD[-p1 + q1], 1}}, {{x[1] + \
+x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID30",
+"FCSymanzikPolynomials[FAD[{p1,m},p1+q1,p3,p1-p3],{p1,p3},Names\
+\[Rule]x,FCE\[Rule]True]",
+"{x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[2]*x[4] + x[3]*x[4],
+m^2*x[1]^2*x[2] + m^2*x[1]^2*x[3] + m^2*x[1]*x[2]*x[3] +
+m^2*x[1]*x[2]*x[4] - SPD[q1, q1]*x[1]*x[2]*x[4] +
+m^2*x[1]*x[3]*x[4] - SPD[q1, q1]*x[1]*x[3]*x[4] -
+SPD[q1, q1]*x[2]*x[3]*x[4], {{x[1], FAD[{p1, m}], 1}, {x[2],
+FAD[p1 - p3], 1}, {x[3], FAD[p3], 1}, {x[4], FAD[p1 + q1],
+1}}, {{x[1] + x[2] + x[4], -x[2]}, {-x[2], x[2] + x[3]}}}"},
+{"fcstFCSymanzikPolynomials-ID31",
+"FCSymanzikPolynomials[FAD[{q,m0},{q-p1,m1}],{q},Names\[Rule]x,FCE\
+\[Rule]True]",
+"{x[1] + x[2], m0^2*x[1]^2 + m0^2*x[1]*x[2] + m1^2*x[1]*x[2] - \
+SPD[p1, p1]*x[1]*x[2] + m1^2*x[2]^2, {{x[1], FAD[{q, m0}], 1}, {x[2], \
+FAD[{-p1 + q, m1}], 1}}, {{x[1] + x[2]}}}"},
+{"fcstFCSymanzikPolynomials-ID32",
+"FCSymanzikPolynomials[FAD[{q,m0},{q-p1,m1},{q-p2,m2}],{q},Names\
+\[Rule]x,FCE\[Rule]True]",
+"{x[1] + x[2] + x[3], m0^2*x[1]^2 + m0^2*x[1]*x[2] + \
+m1^2*x[1]*x[2] - SPD[p1, p1]*x[1]*x[2] + m1^2*x[2]^2 + m0^2*x[1]*x[3] \
++ m2^2*x[1]*x[3] - SPD[p2, p2]*x[1]*x[3] + m1^2*x[2]*x[3] + \
+m2^2*x[2]*x[3] - SPD[p1, p1]*x[2]*x[3] + 2*SPD[p1, p2]*x[2]*x[3] - \
+SPD[p2, p2]*x[2]*x[3] + m2^2*x[3]^2, {{x[1], FAD[{q, m0}], 1}, {x[2], \
+FAD[{-p1 + q, m1}], 1}, {x[3], FAD[{-p2 + q, m2}], 1}}, {{x[1] + x[2] \
++ x[3]}}}"},
+{"fcstFCSymanzikPolynomials-ID33",
+"FCSymanzikPolynomials[FAD[{q,m0},{q-p1,m1},{q-p2,m2},{q-p3,m3}],{\
+q},Names\[Rule]x,FCE\[Rule]True]",
+"{x[1] + x[2] + x[3] + x[4], m0^2*x[1]^2 + m0^2*x[1]*x[2] + \
+m1^2*x[1]*x[2] - SPD[p1, p1]*x[1]*x[2] + m1^2*x[2]^2 + m0^2*x[1]*x[3] \
++ m2^2*x[1]*x[3] - SPD[p2, p2]*x[1]*x[3] + m1^2*x[2]*x[3] + \
+m2^2*x[2]*x[3] - SPD[p1, p1]*x[2]*x[3] + 2*SPD[p1, p2]*x[2]*x[3] - \
+SPD[p2, p2]*x[2]*x[3] + m2^2*x[3]^2 + m0^2*x[1]*x[4] + m3^2*x[1]*x[4] \
+- SPD[p3, p3]*x[1]*x[4] + m1^2*x[2]*x[4] + m3^2*x[2]*x[4] - SPD[p1, \
+p1]*x[2]*x[4] + 2*SPD[p1, p3]*x[2]*x[4] - SPD[p3, p3]*x[2]*x[4] + \
+m2^2*x[3]*x[4] + m3^2*x[3]*x[4] - SPD[p2, p2]*x[3]*x[4] + 2*SPD[p2, \
+p3]*x[3]*x[4] - SPD[p3, p3]*x[3]*x[4] + m3^2*x[4]^2, {{x[1], FAD[{q, \
+m0}], 1}, {x[2], FAD[{-p1 + q, m1}], 1}, {x[3], FAD[{-p2 + q, m2}], \
+1}, {x[4], FAD[{-p3 + q, m3}], 1}}, {{x[1] + x[2] + x[3] + x[4]}}}"},
+{"fcstFCSymanzikPolynomials-ID34",
+"FCSymanzikPolynomials[SFAD[{p, m^2, n}], {p}, Names -> x,
+Indexed -> False, FCE -> True]",
+"{x1, m^2 x1^2, {{x1, SFAD[{{p, 0}, {m^2, 1}, 1}], n}}, {{x1}}}"},
+{"fcstFCSymanzikPolynomials-ID35",
+"FCSymanzikPolynomials[GFAD[SPD[p] - m^2], {p}, Names -> x,
+Indexed -> False, FCE -> True]",
+"{x1, m^2 x1^2, {{x1, GFAD[{{-m^2 + SPD[p, p], 1}, 1}], 1}}, {{x1}}}"},
+{"fcstFCSymanzikPolynomials-ID36",
+"FCSymanzikPolynomials[GFAD[SPD[p] - m^2] FAD[{p, m}], {p}, Names -> x,
+Indexed -> False, FCE -> True]",
+"{x1 + x2,
+m^2 (x1 + x2)^2, {{x1, GFAD[{{-m^2 + SPD[p, p], 1}, 1}], 1}, {x2,
+FAD[{p, m}], 1}}, {{x1 + x2}}}"}
+});


### PR DESCRIPTION
The main purpose of this PR is to have a set of routines that are useful for calculating
multi-loop scalar integrals using direct Feynman parametrization.

In simple cases the integral might be solvable directly withing Mathematica.
However, in most cases one would probably pass it to PolyLogTools or HyperInt

Remaining tasks
- [x] Support for scalar integrals with irreducible scalar products and tensor integrals with free indices (cf. Eq. 4.16 in S. Jahn's thesis)
- [ ] Add other parametrizations: Schwinger, Lee-Pomeransky, Baikov etc.
- [x] Routines for projectivizing an integral in the given variables
- [x] Documentation with many examples
- [x] More unit tests
- [x] Review old `FeynmanParametrize`,  `FeynmanParametrize1`,  `FeynmanReduce` and `FeynmanDoIntegrals`. Keep useful stuff, remove the rest.
- [ ] Export to Maple (for the evaluation via HyperInt)?