### PR TITLE
Gordon identities

### DIFF
--- a/FeynCalc/Dirac/Chisholm.m
+++ b/FeynCalc/Dirac/Chisholm.m
@@ -34,19 +34,21 @@ Begin["`Chisholm`Private`"]
 chVerbose::usage="";
 
 Options[Chisholm] = {
-	Contract 			-> True,
-	DiracSigmaExplicit	-> False,
-	DiracSimplify		-> True,
-	DotSimplify			-> True,
-	FCDiracIsolate		-> True,
-	FCE					-> False,
-	FCI					-> False,
-	FCJoinDOTs			-> True,
-	FCVerbose			-> False,
-	InsideDiracTrace	-> False,
-	MaxIterations		-> Infinity,
-	Mode				-> 1,
-	NonCommutative 		-> True
+	Contract 					-> True,
+	DiracSigmaExplicit			-> False,
+	DiracSimplify				-> True,
+	DiracSpinorNormalization	-> "Relativistic",
+	DotSimplify					-> True,
+	FCDiracIsolate				-> True,
+	FCE							-> False,
+	FCI							-> False,
+	FCJoinDOTs					-> True,
+	FCVerbose					-> False,
+	InsideDiracTrace			-> False,
+	MaxIterations				-> Infinity,
+	Mode						-> 1,
+	NonCommutative 				-> True,
+	SpinorChainEvaluate			-> True
 };
 
 Chisholm[a_ == b_, opts:OptionsPattern[]] :=
@@ -261,7 +263,9 @@ Chisholm[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
 		If[	OptionValue[DiracSimplify],
 				time=AbsoluteTime[];
 				FCPrint[1, "Chisholm: Applying DiracSimplify.", FCDoControl->chVerbose];
-				res = DiracSimplify[res, FCI->True, DiracSigmaExplicit->OptionValue[DiracSigmaExplicit]];
+				res = DiracSimplify[res, FCI->True, DiracSigmaExplicit->OptionValue[DiracSigmaExplicit],
+					SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+					DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 				FCPrint[1, "Chisholm: Done applying DiracSimplify, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->chVerbose]
 		];
 

--- a/FeynCalc/Dirac/DiracReduce.m
+++ b/FeynCalc/Dirac/DiracReduce.m
@@ -38,16 +38,18 @@ Begin["`DiracReduce`Private`"]
 drVerbose::usage="";
 
 Options[DiracReduce] = {
-	Contract 			-> True,
-	DiracGammaCombine	-> True,
-	DiracSimplify		-> False,
-	DiracOrder			-> True,
-	DotSimplify			-> True,
-	FCE					-> False,
-	FCI					-> False,
-	FCVerbose			-> False,
-	Factoring			-> False,
-	FinalSubstitutions	-> {DiracBasis -> Identity}
+	Contract 					-> True,
+	DiracGammaCombine			-> True,
+	DiracSimplify				-> False,
+	DiracSpinorNormalization	-> "Relativistic",
+	DiracOrder					-> True,
+	DotSimplify					-> True,
+	FCE							-> False,
+	FCI							-> False,
+	FCVerbose					-> False,
+	Factoring					-> False,
+	FinalSubstitutions			-> {DiracBasis -> Identity},
+	SpinorChainEvaluate			-> True
 };
 
 DiracReduce[a_ == b_, opts:OptionsPattern[]] :=
@@ -100,7 +102,8 @@ DiracReduce[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
 
 
 
-		tmp = Chisholm[tmp,FCI->True, DiracSimplify -> False];
+		tmp = Chisholm[tmp,FCI->True, DiracSimplify -> False, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+			DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 		FCPrint[3, "DiracReduce: After Chisholm: ", tmp, FCDoControl->drVerbose];
 
 
@@ -112,7 +115,8 @@ DiracReduce[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
 		];
 
 		FCPrint[1, "DiracReduce: Applying Chisholm (mode 2).", FCDoControl->drVerbose];
-		tmp = Chisholm[tmp,FCI->True,DiracSimplify->False,Mode->2];
+		tmp = Chisholm[tmp,FCI->True,DiracSimplify->False,Mode->2, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+			DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 		FCPrint[3, "DiracReduce: After Chisholm: ", tmp, FCDoControl->drVerbose];
 
 		FCPrint[1, "DiracReduce: Introducing DiracSigma.", FCDoControl->drVerbose];
@@ -121,7 +125,8 @@ DiracReduce[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
 
 		If[	diracSimplify,
 			FCPrint[1, "DiracReduce: Applying DiracSimplify.", FCDoControl->drVerbose];
-			tmp = DiracSimplify[tmp, DiracSigmaExplicit -> False, FCI->True, FCCanonicalizeDummyIndices->True];
+			tmp = DiracSimplify[tmp, DiracSigmaExplicit -> False, FCI->True, FCCanonicalizeDummyIndices->True, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+			DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[3, "DiracReduce: After DiracSimplify: ", tmp, FCDoControl->drVerbose]
 		];
 

--- a/FeynCalc/Dirac/GordonSimplify.m
+++ b/FeynCalc/Dirac/GordonSimplify.m
@@ -1,0 +1,256 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: GordonSimplify													*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Applies Gordon identities for spinor chain products			*)
+
+(* ------------------------------------------------------------------------ *)
+
+GordonSimplify::usage =
+"GordonSimplify[exp] rewrites spinor chains describing a vector or an axial-vector
+current using Gordon identities.";
+
+GordonSimplify::failmsg =
+"Error! GordonSimplify has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+(* ------------------------------------------------------------------------ *)
+
+Begin["`Package`"]
+End[]
+
+Begin["`GordonSimplify`Private`"]
+
+gsVerbose::usage="";
+optInverse::usage="";
+holdDOT::usage="";
+
+Options[GordonSimplify] = {
+	DiracGammaCombine 			-> True,
+	DiracSigmaExplicit 			-> False,
+	FCDiracIsolate				-> True,
+	FCE 						-> False,
+	FCI 						-> False,
+	FCJoinDOTs 					-> True,
+	FCVerbose 					-> False,
+	Factoring					-> {Factor2, 5000},
+	Inverse 					-> First,
+	Select 						-> {
+		{Spinor[__], DiracGamma[__], DiracGamma[5], Spinor[__]},
+		{Spinor[__], DiracGamma[__], DiracGamma[6], Spinor[__]},
+		{Spinor[__], DiracGamma[__], Spinor[__]}
+	},
+	TimeConstrained				-> 3
+};
+
+GordonSimplify[a_ == b_, opts:OptionsPattern[]] :=
+	GordonSimplify[a,opts] == GordonSimplify[b,opts];
+
+GordonSimplify[expr_List, opts:OptionsPattern[]]:=
+	GordonSimplify[#, opts]&/@expr;
+
+GordonSimplify[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
+	Block[{ex, tmp,  res, diracObjects, diracObjectsEval, null1, null2, dsHead, time, repRule, mode,
+			optDiracSigmaExplicit, optDiracGammaCombine,  chainPatterns, optSelect},
+
+		optDiracSigmaExplicit			= OptionValue[DiracSigmaExplicit];
+		optDiracGammaCombine			= OptionValue[DiracGammaCombine];
+		optSelect						= FCI[OptionValue[Select]];
+		optInverse						= OptionValue[Inverse];
+
+		FCPrint[1, "GordonSimplify. Entering.", FCDoControl->gsVerbose];
+		FCPrint[3, "GordonSimplify: Entering with ", expr, FCDoControl->gsVerbose];
+
+		If[	!MatchQ[optSelect, {{Spinor[__], DiracGamma[__].., Spinor[__]}..}],
+			Message[GordonSimplify::failmsg,"The value of the Select option is not a valid list of filters."];
+			Abort[]
+		];
+
+		chainPatterns = Map[holdDOT[Sequence@@#] &, optSelect];
+
+		If[	Length[chainPatterns]===1,
+			chainPatterns = First[chainPatterns],
+			chainPatterns = Alternatives@@chainPatterns
+		];
+
+		If[ OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		If[	FreeQ[ex,Spinor],
+			Return[ex]
+		];
+
+		If[ !FreeQ[ex,DiracChain],
+			ex = ex//. DiracChain[x___, a_Spinor, b_Spinor] :> DOT[a,x,b]
+		];
+
+		If[	OptionValue[FCVerbose]===False,
+			gsVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				gsVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		FCPrint[1, "GordonSimplify: Isolating spinor chains.", FCDoControl->gsVerbose];
+		time=AbsoluteTime[];
+
+		tmp = FCDiracIsolate[ex,FCI->True,Head->dsHead, DotSimplify->True, DiracGammaCombine->optDiracGammaCombine, FCJoinDOTs-> OptionValue[FCJoinDOTs],
+			DiracSigmaExplicit->optDiracSigmaExplicit, LorentzIndex->False, Split->True, DiracGamma->False, Factoring -> OptionValue[Factoring],
+			TimeConstrained -> OptionValue[TimeConstrained]];
+
+		FCPrint[1, "GordonSimplify: Done isolating spinor chains, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->gsVerbose];
+		FCPrint[3, "GordonSimplify: After FCDiracIsolate ", tmp, FCDoControl->gsVerbose];
+
+
+		tmp = tmp /. {
+				dsHead[DOT[a_Spinor,b___,c_Spinor]]/;!MatchQ[holdDOT[a,b,c],chainPatterns] :> DOT[a,b,c]
+		};
+
+		FCPrint[3, "GordonSimplify: After Final selection: ", tmp, FCDoControl->gsVerbose];
+
+
+		diracObjects = Cases[tmp+null1+null2, dsHead[_], Infinity]//Sort//DeleteDuplicates;
+		FCPrint[3,"GordonSimplify: diracObjects: ", diracObjects , FCDoControl->gsVerbose];
+
+		FCPrint[1, "GordonSimplify: Rewriting suitable products of spinor chains.", FCDoControl->gsVerbose];
+		time=AbsoluteTime[];
+		diracObjectsEval = Map[(spinorChainGordonEval[#])&, (diracObjects/.dsHead->Identity/. DOT->holdDOT)];
+		FCPrint[1, "GordonSimplify: Done rewriting products of spinor chains, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->gsVerbose];
+		FCPrint[3, "GordonSimplify: diracObjectsEval: ", diracObjectsEval, FCDoControl->gsVerbose];
+
+
+		diracObjectsEval = diracObjectsEval /. holdDOT->DOT /. spinorChainGordonEval-> Identity;
+
+		FCPrint[1, "GordonSimplify: Inserting Dirac objects back.", FCDoControl->gsVerbose];
+		time=AbsoluteTime[];
+		repRule = Thread[Rule[diracObjects,(diracObjectsEval/. holdDOT->DOT)]];
+		FCPrint[3,"GordonSimplify: repRule: ",repRule , FCDoControl->gsVerbose];
+		res =  (tmp/. Dispatch[repRule]);
+		FCPrint[1, "GordonSimplify: Done inserting Dirac objects back, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->gsVerbose];
+
+		If[ OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1, "GordonSimplify: Leaving.", FCDoControl->gsVerbose];
+		FCPrint[3, "GordonSimplify: Leaving with ", res, FCDoControl->gsVerbose];
+
+
+
+		res
+
+	];
+
+holdDOT[___,0,___]:=
+	0;
+
+ga67Switch[7]=
+	6;
+
+ga67Switch[6]=
+	7;
+
+(* Nonchiral identities*)
+
+(* ubar g^mu u or vbar g^mu v, for equal and unequal masses *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], (s2:Spinor[sign_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	I*sign/(m1+m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]],s2] +
+	sign/(m1+m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,s2]/; (m1=!=0 || m2=!=0);
+
+(* ubar g^mu v or vbar g^mu u, unequal masses *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign1_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], (s2:Spinor[sign2_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	I*sign1/(m1-m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]],s2] +
+	sign1/(m1-m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,s2]/; ((m1=!=m2) && (sign1=!=sign2));
+
+(* Chiral identities*)
+
+(* ubar g^mu g^5 u or vbar g^mu g^5 v,  m1=!=m2, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[5], (s2:Spinor[sign_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	I*sign/(m1-m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[5],s2] +
+	sign/(m1-m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1, DiracGamma[5],s2]/; (m1=!=m2) &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+(* ubar g^mu g^5 v or vbar g^mu g^5 u, equal mass case included, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign1_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[5], (s2:Spinor[sign2_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	I*sign1/(m1+m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[5],s2] +
+	sign1/(m1+m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1, DiracGamma[5],s2]/; (sign1=!=sign2) && (m1=!=0 || m2=!=0) &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+
+(* ubar g^mu g^5 u or vbar g^mu g^5 v,  m1=!=m2, D-dim with BMHV *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign_. Momentum[p1_,dim_Symbol] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim_Symbol], DiracGamma[5], (s2:Spinor[sign_.  Momentum[p2_,dim_Symbol] , m2_,___])]]:=
+	-2*sign/(m1-m2)*holdDOT[s1, DiracGamma[arg,dim], DiracGamma[Momentum[p2,dim-4], dim-4], DiracGamma[5],s2] +
+	I*sign/(m1-m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[5],s2] +
+	sign/(m1-m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1, DiracGamma[5],s2]/; (m1=!=m2) &&
+	MemberQ[{"BMHV"},FeynCalc`Package`DiracGammaScheme];
+
+(* ubar g^mu g^5 v or vbar g^mu g^5 u, equal mass case included, D-dim with BMHV *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign1_. Momentum[p1_,dim_Symbol] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim_Symbol], DiracGamma[5], (s2:Spinor[sign2_.  Momentum[p2_,dim_Symbol] , m2_,___])]]:=
+	-2*sign1/(m1+m2)*holdDOT[s1, DiracGamma[arg,dim], DiracGamma[Momentum[p2,dim-4], dim-4], DiracGamma[5],s2] +
+	I*sign1/(m1+m2)*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[5],s2] +
+	sign1/(m1+m2)*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1, DiracGamma[5],s2]/; (sign1=!=sign2) && (m1=!=0 || m2=!=0) &&
+	MemberQ[{"BMHV"},FeynCalc`Package`DiracGammaScheme];
+
+(* In the unequal mass case there are two possibilities: we can have 1/m1 or 1/m2 *)
+
+(* ubar g^mu P_{R/L} u or vbar g^mu P_{R/L} v, 1/m1, equal mass case included, m2=0 allowed, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[chiral:(6|7)], (s2:Spinor[sign_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	- m2/m1 holdDOT[s1,DiracGamma[arg,dim],DiracGamma[ga67Switch[chiral]],s2] +
+	I*sign/m1*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[chiral],s2] +
+	sign/m1*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,DiracGamma[chiral],s2]/; (m1=!=0) &&
+	((optInverse===First) || MemberQ[optInverse, m1])  &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+
+(* vbar g^mu P_{R/L} u or ubar g^mu P_{R/L} v, 1/m1, equal mass case included, m2=0 allowed, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign1_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[chiral:(6|7)], (s2:Spinor[sign2_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	m2/m1 holdDOT[s1,DiracGamma[arg,dim],DiracGamma[ga67Switch[chiral]],s2] +
+	I*sign1/m1*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[chiral],s2] +
+	sign1/m1*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,DiracGamma[chiral],s2]/; (m1=!=0) && (sign1=!=sign2) &&
+	((optInverse===First) || MemberQ[optInverse, m1])  &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+(* ubar g^mu P_{R/L} u or vbar g^mu P_{R/L} v, 1/m2, equal mass case included, m1=0 allowed, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[chiral:(6|7)], (s2:Spinor[sign_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	- m1/m2 holdDOT[s1,DiracGamma[arg,dim],DiracGamma[ga67Switch[chiral]],s2] +
+	I*sign/m2*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[ga67Switch[chiral]],s2] +
+	sign/m2*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,DiracGamma[ga67Switch[chiral]],s2]/; (m2=!=0) &&
+	((optInverse===Last) || MemberQ[optInverse, m2])  &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+
+(* vbar g^mu P_{R/L} u or ubar g^mu P_{R/L} v, 1/m2, equal mass case included, m1=0 allowed, D=4 or D-dim with NDR *)
+spinorChainGordonEval[holdDOT[(s1:Spinor[sign1_. Momentum[p1_,dim___] , m1_,___]), DiracGamma[arg: (_LorentzIndex | _ExplicitLorentzIndex |
+	_Momentum | _CartesianIndex | _CartesianMomentum), dim___], DiracGamma[chiral:(6|7)], (s2:Spinor[sign2_.  Momentum[p2_,dim___] , m2_,___])]]:=
+	m1/m2 holdDOT[s1,DiracGamma[arg,dim],DiracGamma[ga67Switch[chiral]],s2] -
+	I*sign1/m2*holdDOT[s1,DiracSigma[DiracGamma[arg,dim], DiracGamma[Momentum[p1-p2,dim],dim]], DiracGamma[ga67Switch[chiral]],s2] -
+	sign1/m2*Pair[Momentum[p1+p2,dim],arg] holdDOT[s1,DiracGamma[ga67Switch[chiral]],s2]/; ((m2=!=0) && (sign1=!=sign2)) &&
+	((optInverse===Last) || MemberQ[optInverse, m2])  &&
+	(!MatchQ[dim,_Symbol | _Symbol-4] || MemberQ[{"NDR","NDR-Discard"},FeynCalc`Package`DiracGammaScheme]);
+
+
+
+
+
+FCPrint[1,"GordonSimplify.m loaded"];
+End[]

--- a/FeynCalc/Dirac/SpinorChainEvaluate.m
+++ b/FeynCalc/Dirac/SpinorChainEvaluate.m
@@ -1,0 +1,211 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: SpinorChainEvaluate													*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Simplification rules for products of spinor chains			*)
+
+(* ------------------------------------------------------------------------ *)
+
+SpinorChainEvaluate::usage =
+"SpinorChainEvaluate[exp] explicitly evaluates suitable spinor chains, i.e. \
+replaces a DOT[Spinor[...],...,Spinor[...]] with a scalar quantity without a \
+DOT.";
+
+SpinorChainEvaluate::failmsg =
+"Error! SpinorChainEvaluate has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+(* ------------------------------------------------------------------------ *)
+
+Begin["`Package`"]
+End[]
+
+Begin["`SpinorChainEvaluate`Private`"]
+
+holdDOT::usage="";
+spcheVerbose::usage="";
+normFun::usage="";
+
+Options[SpinorChainEvaluate] = {
+	Collecting 					-> True,
+	DiracSpinorNormalization	-> "Relativistic",
+	FCE 						-> False,
+	FCI 						-> False,
+	FCVerbose 					-> False,
+	Factoring					-> {Factor2, 5000},
+	TimeConstrained				-> 3
+};
+
+
+SpinorChainEvaluate[a_ == b_, opts:OptionsPattern[]] :=
+	SpinorChainEvaluate[a,opts] == SpinorChainEvaluate[b,opts];
+
+SpinorChainEvaluate[expr_List, opts:OptionsPattern[]]:=
+	SpinorChainEvaluate[#, opts]&/@expr;
+
+SpinorChainEvaluate[expr_/; !MemberQ[{List,Equal},expr], OptionsPattern[]] :=
+	Block[{	ex, tmp, dsHead, null1, null2, time, diracObjects, diracObjectsEval, repRule, res},
+
+		If[	OptionValue[FCVerbose]===False,
+			spcheVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				spcheVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		FCPrint[1, "SpinorChainEvaluate. Entering.", FCDoControl->spcheVerbose];
+		FCPrint[3, "SpinorChainEvaluate: Entering with ", ex, FCDoControl->spcheVerbose];
+
+		If[ OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		If[	FreeQ[ex,Spinor],
+			Return[ex]
+		];
+
+		Switch[
+			OptionValue[DiracSpinorNormalization],
+			"Relativistic",
+				FCPrint[1, "SpinorChainEvaluate: Relativistic normalization selected.", FCDoControl->spcheVerbose];
+				normFun = relNormalization,
+			"Rest",
+				FCPrint[1, "SpinorChainEvaluate: Rest normalization selected.", FCDoControl->spcheVerbose];
+				normFun = restNormalization,
+			"Nonrelativistic",
+				FCPrint[1, "SpinorChainEvaluate: Nonrelativistic normalization selected.", FCDoControl->spcheVerbose];
+				normFun = nrNormalization,
+			_,
+				Message[SpinorChainEvaluate::failmsg,"Unknown kinematic configuration"];
+				Abort[]
+		];
+
+		If[	MatchQ[ex, DOT[a_Spinor,b___,c_Spinor]/;FreeQ[{b},Spinor]],
+
+			FCPrint[1, "SpinorChainEvaluate: Recognized a standalone expression.", FCDoControl->spcheVerbose];
+			tmp = dsHead[ex];
+			diracObjects  = {dsHead[ex]},
+
+			FCPrint[1, "SpinorChainEvaluate: Isolating spinor chains.", FCDoControl->spcheVerbose];
+			time=AbsoluteTime[];
+			tmp = FCDiracIsolate[ex,FCI->True, Head->dsHead, Spinor->True, Collecting-> OptionValue[Collecting], DiracGamma->False, Factoring -> OptionValue[Factoring]];
+			FCPrint[1, "SpinorChainEvaluate: Done isolating spinor chains, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->spcheVerbose];
+			FCPrint[3, "SpinorChainEvaluate: After FCDiracIsolate ", tmp, FCDoControl->spcheVerbose];
+
+			diracObjects = Cases[tmp+null1+null2, dsHead[_], Infinity]//Sort//DeleteDuplicates;
+
+		];
+
+		FCPrint[3,"SpinorChainEvaluate: diracObjects: ", diracObjects , FCDoControl->spcheVerbose];
+
+
+		FCPrint[1, "SpinorChainEvaluate: Evaluating suitable spinor chains.", FCDoControl->spcheVerbose];
+		time=AbsoluteTime[];
+		diracObjectsEval = Map[spinorChainEval, (diracObjects/.dsHead->Identity/. DOT->holdDOT)] /. spinorChainEval->Identity;
+		FCPrint[1, "SpinorChainEvaluate: Done evaluating spinor chains, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->spcheVerbose];
+		FCPrint[3, "SpinorChainEvaluate: diracObjectsEval: ", diracObjectsEval, FCDoControl->spcheVerbose];
+
+
+		If[	!FreeQ2[diracObjectsEval,{relNormalization,restNormalization,nrNormalization,normFun}],
+			Message[SpinorChainEvaluate::failmsg, "Failed to evaluate suitable spinor chains."];
+			Abort[]
+		];
+
+
+		FCPrint[1, "SpinorChainEvaluate: Inserting Dirac objects back.", FCDoControl->spcheVerbose];
+		time=AbsoluteTime[];
+		repRule = Thread[Rule[diracObjects,(diracObjectsEval/.holdDOT->DOT)]];
+
+		FCPrint[3,"SpinorChainEvaluate: repRule: ",repRule , FCDoControl->spcheVerbose];
+
+		res =  (tmp /. Dispatch[repRule]);
+
+		FCPrint[1, "SpinorChainEvaluate: Done inserting Dirac objects back, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->spcheVerbose];
+
+		If[ OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1, "SpinorChainEvaluate: Leaving.", FCDoControl->spcheVerbose];
+		FCPrint[3, "SpinorChainEvaluate: Leaving with ", res, FCDoControl->spcheVerbose];
+
+		res
+
+	];
+
+relNormalization[Momentum[___], m_]:=
+	2 m;
+
+restNormalization[Momentum[___], _]:=
+	1;
+
+nrNormalization[Momentum[p_,___], m_]:=
+	m / TemporalPair[ExplicitLorentzIndex[0], TemporalMomentum[p]];
+
+(* massive/massless, ubar(p).u(p) and vbar(p).v(p) *)
+spinorChainEval[holdDOT[Spinor[s_. Momentum[p__],m_, 1],Spinor[s_. Momentum[p__],m_, 1]]]:=
+	s*normFun[Momentum[p],m];
+
+(* massive/massless, ubar(p).v(p) and vbar(p).u(p) *)
+spinorChainEval[holdDOT[Spinor[Momentum[p__],m_, 1],Spinor[-Momentum[p__],m_, 1]]]:=
+	0;
+
+spinorChainEval[holdDOT[Spinor[-Momentum[p__],m_, 1],Spinor[Momentum[p__],m_, 1]]]:=
+	0;
+
+(*
+	Here we should be careful: In 4 dimensions these relations obviously hold
+	In D-dimensions with D-dim spinors the derivation relies on the fact that g^5 is anticommuting.
+	In a BMHV-like scheme where the spinors are D-dimensional, the product does not
+	vanish, cf. e.g.
+
+	FCSetDiracGammaScheme["BMHV"];
+	SpinorUBarD[p1, m].DiracSigma[GAD[mu], GSD[p1 - p2]].GAD[5].SpinorUD[p2, m] // DiracSimplify[#, DiracOrder -> True] &
+	% /. p1 | p2 -> p
+*)
+
+(* massive/massless, ubar(p).g^5.u(p) and vbar(p).g^5.v(p) *)
+spinorChainEval[holdDOT[Spinor[s_. Momentum[p_],m_, 1],DiracGamma[5],Spinor[s_. Momentum[p_],m_, 1]]]:=
+	0;
+
+
+spinorChainEval[holdDOT[Spinor[s_. Momentum[p_,dim_Symbol],m_, 1],DiracGamma[5],Spinor[s_. Momentum[p_,dim_Symbol],m_, 1]]]:=
+	0 /; MemberQ[{"NDR", "NDR-Discard"},FeynCalc`Package`DiracGammaScheme];
+
+(* massless particles *)
+
+(* massless, ubar(p).g^{6|7}.u(p) and vbar(p).g^{6|7}.v(p) *)
+spinorChainEval[holdDOT[Spinor[s_. Momentum[p_], 0, 1],DiracGamma[6|7],Spinor[s_. Momentum[p_], 0, 1]]]:=
+	0;
+
+
+spinorChainEval[holdDOT[Spinor[s_. Momentum[p_,dim_Symbol], 0, 1],DiracGamma[6|7],Spinor[s_. Momentum[p_,dim_Symbol], 0, 1]]]:=
+	0 /; MemberQ[{"NDR", "NDR-Discard"},FeynCalc`Package`DiracGammaScheme];
+
+(* ubar(p).g^{5|6|7}.v(p) and vbar(p).g^{5|6|7}.u(p) *)
+spinorChainEval[holdDOT[Spinor[Momentum[p_], 0, 1],DiracGamma[5|6|7],Spinor[-Momentum[p_], 0, 1]]]:=
+	0;
+
+spinorChainEval[holdDOT[Spinor[-Momentum[p_], 0, 1],DiracGamma[5|6|7],Spinor[Momentum[p_], 0, 1]]]:=
+	0;
+
+spinorChainEval[holdDOT[Spinor[Momentum[p_,dim_Symbol], 0, 1],DiracGamma[5|6|7],Spinor[-Momentum[p_,dim_Symbol], 0, 1]]]:=
+	0 /; MemberQ[{"NDR", "NDR-Discard"},FeynCalc`Package`DiracGammaScheme];
+
+spinorChainEval[holdDOT[Spinor[-Momentum[p_,dim_Symbol], 0, 1],DiracGamma[5|6|7],Spinor[Momentum[p_,dim_Symbol], 0, 1]]]:=
+	0 /; MemberQ[{"NDR", "NDR-Discard"},FeynCalc`Package`DiracGammaScheme];
+
+
+
+FCPrint[1,"SpinorChainEvaluate.m loaded"];
+End[]

--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/DiracSimplify.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/DiracSimplify.nb
@@ -322,6 +322,11 @@ Cell[TextData[{
   ButtonData:>"paclet:FeynCalc/ref/SpinorChainTrick",
   ButtonNote->"SpinorChainTrick"],
  ", ",
+ ButtonBox["SpinorChainEvaluate",
+  BaseStyle->"Link",
+  ButtonData:>"paclet:FeynCalc/ref/SpinorChainEvaluate",
+  ButtonNote->"SpinorChainEvaluate"],
+ ", ",
  ButtonBox["ToDiracGamma67",
   BaseStyle->"Link",
   ButtonData:>"paclet:FeynCalc/ref/ToDiracGamma67",
@@ -7472,6 +7477,114 @@ Cell[BoxData[
         TraditionalForm]}], ")"}]}]}]}], TraditionalForm]], "Output",
  CellLabel->"Out[17]="]
 }, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["\t", "ExampleDelimiter"],
+  $Line = 0; Null]], "ExampleDelimiter"],
+
+Cell[TextData[{
+ ButtonBox["DiracSimplify",
+  BaseStyle->"Link",
+  ButtonData:>"paclet:FeynCalc/ref/DiracSimplify",
+  ButtonNote->"DiracSimplify"],
+ " automatically evaluates suitable spinor products with equal momenta, e.g."
+}], "Notes"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{"SpinorUBar", "[", 
+    RowBox[{"p", ",", "m"}], "]"}], ".", 
+   RowBox[{"SpinorU", "[", 
+    RowBox[{"p", ",", "m"}], "]"}]}]}]], "Input",
+ CellLabel->"In[20]:="],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["u", "_"], "(", 
+    FormBox["p",
+     TraditionalForm], ",", 
+    FormBox["m",
+     TraditionalForm], ")"}], ".", 
+   RowBox[{"u", "(", 
+    FormBox["p",
+     TraditionalForm], ",", 
+    FormBox["m",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellLabel->"Out[20]="]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"DiracSimplify", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[21]:="],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"2", " ", "m"}], TraditionalForm]], "Output",
+ CellLabel->"Out[21]="]
+}, Open  ]],
+
+Cell["\<\
+This behavior can be turned off by setting the option SpinorChainEvaluate to \
+False\
+\>", "Notes"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"DiracSimplify", "[", 
+  RowBox[{"ex", ",", 
+   RowBox[{"SpinorChainEvaluate", "\[Rule]", "False"}]}], "]"}]], "Input",
+ CellLabel->"In[22]:="],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      OverscriptBox[
+       FormBox["p",
+        TraditionalForm], "_"],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}], ".", 
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      OverscriptBox[
+       FormBox["p",
+        TraditionalForm], "_"],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}]}], TraditionalForm]], "Output",
+ CellLabel->"Out[22]="]
+}, Open  ]]
 }, Open  ]]
 }, Open  ]],
 
@@ -7536,7 +7649,7 @@ Cell[BoxData[
 }, Open  ]]
 },
 WindowSize->{894, 989},
-WindowMargins->{{Automatic, 200}, {Automatic, -8}},
+WindowMargins->{{Automatic, 190}, {Automatic, -8}},
 Visible->True,
 PrivateNotebookOptions->{"FileOutlineCache"->False},
 CreateCellID->False,

--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/GordonSimplify.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/GordonSimplify.nb
@@ -1,0 +1,2300 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 10.4' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     59960,       2292]
+NotebookOptionsPosition[     53081,       2041]
+NotebookOutlinePosition[     53696,       2065]
+CellTagsIndexPosition[     53616,       2060]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[TextData[{
+ "New in: ",
+ Cell["9.3", "HistoryData",
+  CellTags->"New"],
+ " | Modified in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Modified"],
+ " | Obsolete in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Obsolete"],
+ " | Excised in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Excised"]
+}], "History",
+ CellID->1247902091],
+
+Cell[CellGroupData[{
+
+Cell["Categorization", "CategorizationSection",
+ CellID->1122911449],
+
+Cell["Symbol", "Categorization",
+ CellLabel->"Entity Type",
+ CellID->686433507],
+
+Cell["FeynCalc", "Categorization",
+ CellLabel->"Paclet Name",
+ CellID->605800465],
+
+Cell["FeynCalc`", "Categorization",
+ CellLabel->"Context",
+ CellID->468444828],
+
+Cell["FeynCalc/ref/GordonSimplify", "Categorization",
+ CellLabel->"URI"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Keywords", "KeywordsSection",
+ CellID->477174294],
+
+Cell["XXXX", "Keywords",
+ CellID->1164421360]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Syntax Templates", "TemplatesSection",
+ CellID->1872225408],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Additional Function Template",
+ CellID->1562036412],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Arguments Pattern",
+ CellID->158391909],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Local Variables",
+ CellID->1360575930],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Color Equal Signs",
+ CellID->793782254]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Details", "DetailsSection",
+ CellID->307771771],
+
+Cell["XXXX", "Details",
+ CellLabel->"Lead",
+ CellID->670882175],
+
+Cell["XXXX", "Details",
+ CellLabel->"Developers",
+ CellID->350963985],
+
+Cell["XXXX", "Details",
+ CellLabel->"Authors",
+ CellID->8391405],
+
+Cell["XXXX", "Details",
+ CellLabel->"Feature Name",
+ CellID->3610269],
+
+Cell["XXXX", "Details",
+ CellLabel->"QA",
+ CellID->401364205],
+
+Cell["XXXX", "Details",
+ CellLabel->"DA",
+ CellID->350204745],
+
+Cell["XXXX", "Details",
+ CellLabel->"Docs",
+ CellID->732958810],
+
+Cell["XXXX", "Details",
+ CellLabel->"Features Page Notes",
+ CellID->222905350],
+
+Cell["XXXX", "Details",
+ CellLabel->"Comments",
+ CellID->240026365]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["GordonSimplify", "ObjectName",
+ CellID->1224892054],
+
+Cell[TextData[{
+ Cell["   ", "ModInfo"],
+ Cell[BoxData[
+  RowBox[{"GordonSimplify", "[", "exp", "]"}]], "InlineFormula"],
+ " \[LineSeparator]rewrites spinor chains describing a vector or an \
+axial-vector current using Gordon identities."
+}], "Usage",
+ CellChangeTimes->{{3.806510124135243*^9, 3.806510134164617*^9}},
+ CellID->982511436],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Options", "[", "GordonSimplify", "]"}]], "Input",
+ CellChangeTimes->{{3.806510147125005*^9, 3.806510150205358*^9}},
+ CellLabel->"In[9]:=",
+ CellID->250226562],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"{", 
+   RowBox[{
+    RowBox[{"DiracGammaCombine", "\[Rule]", "True"}], ",", 
+    RowBox[{"DiracSigmaExplicit", "\[Rule]", "False"}], ",", 
+    RowBox[{"FCDiracIsolate", "\[Rule]", "True"}], ",", 
+    RowBox[{"FeynCalcExternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FeynCalcInternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FCJoinDOTs", "\[Rule]", "True"}], ",", 
+    RowBox[{"FCVerbose", "\[Rule]", "False"}], ",", 
+    RowBox[{"Factoring", "\[Rule]", 
+     RowBox[{"{", 
+      RowBox[{"Factor2", ",", "5000"}], "}"}]}], ",", 
+    RowBox[{"Inverse", "\[Rule]", "First"}], ",", 
+    RowBox[{"Select", "\[Rule]", 
+     RowBox[{"{", 
+      RowBox[{
+       RowBox[{"{", 
+        RowBox[{
+         RowBox[{"Spinor", "(", "__", ")"}], ",", 
+         RowBox[{"DiracGamma", "(", "__", ")"}], ",", 
+         SuperscriptBox[
+          OverscriptBox["\[Gamma]", "_"], 
+          FormBox["5",
+           TraditionalForm]], ",", 
+         RowBox[{"Spinor", "(", "__", ")"}]}], "}"}], ",", 
+       RowBox[{"{", 
+        RowBox[{
+         RowBox[{"Spinor", "(", "__", ")"}], ",", 
+         RowBox[{"DiracGamma", "(", "__", ")"}], ",", 
+         SuperscriptBox[
+          OverscriptBox["\[Gamma]", "_"], 
+          FormBox["6",
+           TraditionalForm]], ",", 
+         RowBox[{"Spinor", "(", "__", ")"}]}], "}"}], ",", 
+       RowBox[{"{", 
+        RowBox[{
+         RowBox[{"Spinor", "(", "__", ")"}], ",", 
+         RowBox[{"DiracGamma", "(", "__", ")"}], ",", 
+         RowBox[{"Spinor", "(", "__", ")"}]}], "}"}]}], "}"}]}], ",", 
+    RowBox[{"TimeConstrained", "\[Rule]", "3"}]}], "}"}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510161036068*^9},
+ CellLabel->"Out[9]=",
+ CellID->1383488355]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Tutorials", "TutorialsSection",
+ CellID->250839057],
+
+Cell["XXXX", "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Demonstrations", "RelatedDemonstrationsSection",
+ CellID->1268215905],
+
+Cell["XXXX", "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Links", "RelatedLinksSection",
+ CellID->1584193535],
+
+Cell["XXXX", "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["See Also", "SeeAlsoSection",
+ CellID->1255426704],
+
+Cell[TextData[{
+ ButtonBox["DiracGamma",
+  BaseStyle->"Link",
+  ButtonData:>"paclet:FeynCalc/ref/DiracGamma",
+  ButtonNote->"DiracGamma"],
+ ", ",
+ ButtonBox["Spinor",
+  BaseStyle->"Link",
+  ButtonData:>"paclet:FeynCalc/ref/Spinor",
+  ButtonNote->"Spinor"],
+ ", ",
+ ButtonBox["SpinorChainTrick",
+  BaseStyle->"Link",
+  ButtonData:>"paclet:FeynCalc/ref/SpinorChainTrick",
+  ButtonNote->"SpinorChainTrick"],
+ "."
+}], "SeeAlso",
+ CellID->655647701]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More About", "MoreAboutSection",
+ CellID->38303248],
+
+Cell["XXXX", "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[GridBox[{
+    {
+     StyleBox["Examples", "PrimaryExamplesSection"], 
+     ButtonBox[
+      RowBox[{
+       RowBox[{"More", " ", "Examples"}], " ", "\[RightTriangle]"}],
+      BaseStyle->"ExtendedExamplesLink",
+      ButtonData:>"ExtendedExamples"]}
+   }],
+  $Line = 0; Null]], "PrimaryExamplesSection",
+ CellID->880084151],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"SpinorUBar", "[", 
+   RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+  RowBox[{"GA", "[", "\[Mu]", "]"}], ".", 
+  RowBox[{"SpinorU", "[", 
+   RowBox[{"p2", ",", "m2"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.80651018750382*^9, 3.806510247855742*^9}},
+ CellLabel->"In[15]:=",
+ CellID->356943878],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["u", "_"], "(", 
+    FormBox["p1",
+     TraditionalForm], ",", 
+    FormBox["m1",
+     TraditionalForm], ")"}], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox[
+      FormBox["\[Mu]",
+       TraditionalForm],
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   RowBox[{"u", "(", 
+    FormBox["p2",
+     TraditionalForm], ",", 
+    FormBox["m2",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8065102122777977`*^9, 3.806510248298828*^9}},
+ CellLabel->"Out[15]=",
+ CellID->1292223288]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "%", "]"}]], "Input",
+ CellChangeTimes->{{3.80651021334051*^9, 3.806510220361092*^9}},
+ CellLabel->"In[16]:=",
+ CellID->1614855230],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p1",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p2",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "+", "m2"}]], "+", 
+   FractionBox[
+    RowBox[{"\[ImaginaryI]", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p1",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox["\[Sigma]", 
+       RowBox[{
+        FormBox[
+         FormBox["\[Mu]",
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox[
+         FormBox[
+          RowBox[{
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"], "-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm],
+         TraditionalForm]}]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p2",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "+", "m2"}]]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8065102207077913`*^9, 3.80651024918528*^9}},
+ CellLabel->"Out[16]=",
+ CellID->1149611235]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"SpinorUBar", "[", 
+   RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+  RowBox[{"GA", "[", 
+   RowBox[{"\[Mu]", ",", "5"}], "]"}], ".", 
+  RowBox[{"SpinorV", "[", 
+   RowBox[{"p2", ",", "m2"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.806510237194743*^9, 3.806510263481833*^9}},
+ CellLabel->"In[17]:=",
+ CellID->893086721],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["u", "_"], "(", 
+    FormBox["p1",
+     TraditionalForm], ",", 
+    FormBox["m1",
+     TraditionalForm], ")"}], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox[
+      FormBox["\[Mu]",
+       TraditionalForm],
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox["5",
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   RowBox[{"v", "(", 
+    FormBox["p2",
+     TraditionalForm], ",", 
+    FormBox["m2",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.806510244166003*^9, 3.806510254752185*^9}},
+ CellLabel->"Out[17]=",
+ CellID->1800667857]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "%", "]"}]], "Input",
+ CellLabel->"In[18]:=",
+ CellID->1556234510],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p1",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["5",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "+", "m2"}]], "+", 
+   FractionBox[
+    RowBox[{"\[ImaginaryI]", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         OverscriptBox[
+          FormBox["p1",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox["\[Sigma]", 
+       RowBox[{
+        FormBox[
+         FormBox["\[Mu]",
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox[
+         FormBox[
+          RowBox[{
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"], "-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm],
+         TraditionalForm]}]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["5",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "+", "m2"}]]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510258876731*^9},
+ CellLabel->"Out[18]=",
+ CellID->493727217]
+}, Open  ]],
+
+Cell["\<\
+Relations involving projectors can be used to trade the right projector for a \
+left one\
+\>", "Notes",
+ CellChangeTimes->{{3.806510312503941*^9, 3.8065103466788273`*^9}, 
+   3.806510416217054*^9},
+ CellID->1261016597],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"SpinorVBar", "[", 
+   RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+  RowBox[{"GA", "[", 
+   RowBox[{"\[Mu]", ",", "6"}], "]"}], ".", 
+  RowBox[{"SpinorV", "[", 
+   RowBox[{"p2", ",", "m2"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.8065102678347483`*^9, 3.806510275757305*^9}},
+ CellLabel->"In[22]:=",
+ CellID->981235250],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["v", "_"], "(", 
+    FormBox["p1",
+     TraditionalForm], ",", 
+    FormBox["m1",
+     TraditionalForm], ")"}], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox[
+      FormBox["\[Mu]",
+       TraditionalForm],
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox["6",
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   RowBox[{"v", "(", 
+    FormBox["p2",
+     TraditionalForm], ",", 
+    FormBox["m2",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.806510268244173*^9, 3.806510276160982*^9}, 
+   3.806510348588533*^9},
+ CellLabel->"Out[22]=",
+ CellID->593365759]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "%", "]"}]], "Input",
+ CellLabel->"In[23]:=",
+ CellID->508620888],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{"\[ImaginaryI]", " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox["\[Sigma]", 
+        RowBox[{
+         FormBox[
+          FormBox["\[Mu]",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox[
+           RowBox[{
+            OverscriptBox[
+             FormBox["p1",
+              TraditionalForm], "_"], "-", 
+            OverscriptBox[
+             FormBox["p2",
+              TraditionalForm], "_"]}],
+           TraditionalForm],
+          TraditionalForm]}]], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["6",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], "m1"]}], "-", 
+   FractionBox[
+    RowBox[{"m2", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["7",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"], "-", 
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["6",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510282702729*^9, 3.8065103491997023`*^9},
+ CellLabel->"Out[23]=",
+ CellID->488903717]
+}, Open  ]],
+
+Cell["Use the select option to achieve the opposite", "Notes",
+ CellChangeTimes->{{3.806510312503941*^9, 3.8065103466788273`*^9}, {
+  3.806510416217054*^9, 3.8065104342848454`*^9}},
+ CellID->599661764],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{"SpinorVBar", "[", 
+    RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+   RowBox[{"GA", "[", 
+    RowBox[{"\[Mu]", ",", "7"}], "]"}], ".", 
+   RowBox[{"SpinorV", "[", 
+    RowBox[{"p2", ",", "m2"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.80651035984133*^9, 3.8065103720714197`*^9}},
+ CellLabel->"In[26]:=",
+ CellID->1978201776],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["v", "_"], "(", 
+    FormBox["p1",
+     TraditionalForm], ",", 
+    FormBox["m1",
+     TraditionalForm], ")"}], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox[
+      FormBox["\[Mu]",
+       TraditionalForm],
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox["7",
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   RowBox[{"v", "(", 
+    FormBox["p2",
+     TraditionalForm], ",", 
+    FormBox["m2",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.806510360330682*^9, 3.806510372426025*^9}},
+ CellLabel->"Out[26]=",
+ CellID->283459477]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[27]:=",
+ CellID->1305963384],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      RowBox[{"-", 
+       OverscriptBox[
+        FormBox["p1",
+         TraditionalForm], "_"]}],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m1",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}], ".", 
+   SuperscriptBox[
+    OverscriptBox["\[Gamma]", "_"], 
+    FormBox[
+     FormBox["\[Mu]",
+      TraditionalForm],
+     TraditionalForm]], ".", 
+   SuperscriptBox[
+    OverscriptBox["\[Gamma]", "_"], 
+    FormBox["7",
+     TraditionalForm]], ".", 
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      RowBox[{"-", 
+       OverscriptBox[
+        FormBox["p2",
+         TraditionalForm], "_"]}],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m2",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510373346162*^9},
+ CellLabel->"Out[27]=",
+ CellID->204342930]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", 
+  RowBox[{"ex", ",", 
+   RowBox[{"Select", "\[Rule]", 
+    RowBox[{"{", 
+     RowBox[{"{", 
+      RowBox[{
+       RowBox[{"Spinor", "[", "__", "]"}], ",", 
+       RowBox[{"DiracGamma", "[", "__", "]"}], ",", 
+       RowBox[{"GA", "[", "7", "]"}], ",", 
+       RowBox[{"Spinor", "[", "__", "]"}]}], "}"}], "}"}]}]}], "]"}]], "Input",\
+
+ CellChangeTimes->{{3.806510376556592*^9, 3.806510409036055*^9}},
+ CellLabel->"In[29]:=",
+ CellID->590788495],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{"\[ImaginaryI]", " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox["\[Sigma]", 
+        RowBox[{
+         FormBox[
+          FormBox["\[Mu]",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox[
+           RowBox[{
+            OverscriptBox[
+             FormBox["p1",
+              TraditionalForm], "_"], "-", 
+            OverscriptBox[
+             FormBox["p2",
+              TraditionalForm], "_"]}],
+           TraditionalForm],
+          TraditionalForm]}]], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["7",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], "m1"]}], "-", 
+   FractionBox[
+    RowBox[{"m2", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["6",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"], "-", 
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["7",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.806510402697461*^9, 3.8065104093566027`*^9}},
+ CellLabel->"Out[29]=",
+ CellID->947732373]
+}, Open  ]],
+
+Cell["\<\
+We can choose between having expressions proportional to 1/m1 (mass of the \
+first spinor) or 1/m2 (mass of the second spinor) \
+\>", "Notes",
+ CellChangeTimes->{{3.806510312503941*^9, 3.8065103466788273`*^9}, {
+  3.806510416217054*^9, 3.806510453808669*^9}, {3.8065105092936993`*^9, 
+  3.806510547641718*^9}},
+ CellID->806789778],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"SpinorVBar", "[", 
+     RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+    RowBox[{"GA", "[", 
+     RowBox[{"\[Mu]", ",", "6"}], "]"}], ".", 
+    RowBox[{"SpinorV", "[", 
+     RowBox[{"p2", ",", "m2"}], "]"}]}], ",", 
+   RowBox[{"Inverse", "\[Rule]", "First"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.806510556957492*^9, 3.806510576929348*^9}},
+ CellLabel->"In[41]:=",
+ CellID->60397023],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{"\[ImaginaryI]", " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox["\[Sigma]", 
+        RowBox[{
+         FormBox[
+          FormBox["\[Mu]",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox[
+           RowBox[{
+            OverscriptBox[
+             FormBox["p1",
+              TraditionalForm], "_"], "-", 
+            OverscriptBox[
+             FormBox["p2",
+              TraditionalForm], "_"]}],
+           TraditionalForm],
+          TraditionalForm]}]], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["6",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], "m1"]}], "-", 
+   FractionBox[
+    RowBox[{"m2", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["7",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"], "-", 
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["6",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m1"]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8065105673490953`*^9, 3.80651059621242*^9}},
+ CellLabel->"Out[41]=",
+ CellID->2054711607]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"SpinorVBar", "[", 
+     RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+    RowBox[{"GA", "[", 
+     RowBox[{"\[Mu]", ",", "6"}], "]"}], ".", 
+    RowBox[{"SpinorV", "[", 
+     RowBox[{"p2", ",", "m2"}], "]"}]}], ",", 
+   RowBox[{"Inverse", "\[Rule]", "Last"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.806510602638419*^9, 3.806510603290777*^9}},
+ CellLabel->"In[42]:=",
+ CellID->1605787920],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{"\[ImaginaryI]", " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p1",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox["\[Sigma]", 
+        RowBox[{
+         FormBox[
+          FormBox["\[Mu]",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox[
+           RowBox[{
+            OverscriptBox[
+             FormBox["p1",
+              TraditionalForm], "_"], "-", 
+            OverscriptBox[
+             FormBox["p2",
+              TraditionalForm], "_"]}],
+           TraditionalForm],
+          TraditionalForm]}]], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["7",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           OverscriptBox[
+            FormBox["p2",
+             TraditionalForm], "_"]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], "m2"]}], "-", 
+   FractionBox[
+    RowBox[{"m1", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["7",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m2"], "-", 
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"], "+", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p1",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["7",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          OverscriptBox[
+           FormBox["p2",
+            TraditionalForm], "_"]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], "m2"]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510603617343*^9},
+ CellLabel->"Out[42]=",
+ CellID->918758801]
+}, Open  ]],
+
+Cell["\<\
+In D-dimensions chiral Gordon identities are scheme dependent!\
+\>", "Notes",
+ CellChangeTimes->{{3.806510312503941*^9, 3.8065103466788273`*^9}, {
+  3.806510416217054*^9, 3.806510453808669*^9}},
+ CellID->1055202867],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{"SpinorVBarD", "[", 
+    RowBox[{"p1", ",", "m1"}], "]"}], ".", 
+   RowBox[{"GAD", "[", 
+    RowBox[{"\[Mu]", ",", "5"}], "]"}], ".", 
+   RowBox[{"SpinorVD", "[", 
+    RowBox[{"p2", ",", "m2"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.80651046099778*^9, 3.806510473174882*^9}},
+ CellLabel->"In[30]:=",
+ CellID->1907110618],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   FormBox[
+    RowBox[{
+     OverscriptBox["v", "_"], "(", 
+     FormBox["p1",
+      TraditionalForm], ",", 
+     FormBox["m1",
+      TraditionalForm], ")"}],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox["\[Gamma]", 
+     FormBox[
+      FormBox["\[Mu]",
+       TraditionalForm],
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox["5",
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    RowBox[{"v", "(", 
+     FormBox["p2",
+      TraditionalForm], ",", 
+     FormBox["m2",
+      TraditionalForm], ")"}],
+    TraditionalForm]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.8065104736679993`*^9},
+ CellLabel->"Out[30]=",
+ CellID->1393611744]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"FCGetDiracGammaScheme", "[", "]"}]], "Input",
+ CellChangeTimes->{{3.806510478449635*^9, 3.8065104808857527`*^9}},
+ CellLabel->"In[32]:=",
+ CellID->1967420182],
+
+Cell[BoxData[
+ FormBox["\<\"NDR\"\>", TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510481180563*^9},
+ CellLabel->"Out[32]=",
+ CellID->538351384]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "ex", "]"}]], "Input",
+ CellChangeTimes->{{3.806510470974648*^9, 3.806510475960259*^9}},
+ CellLabel->"In[33]:=",
+ CellID->2132799337],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{
+      SuperscriptBox[
+       RowBox[{"(", 
+        FormBox[
+         FormBox[
+          RowBox[{
+           FormBox["p1",
+            TraditionalForm], "+", 
+           FormBox["p2",
+            TraditionalForm]}],
+          TraditionalForm],
+         TraditionalForm], ")"}], 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           FormBox["p1",
+            TraditionalForm]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["5",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           FormBox["p2",
+            TraditionalForm]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], 
+     RowBox[{"m1", "-", "m2"}]]}], "-", 
+   FractionBox[
+    RowBox[{"\[ImaginaryI]", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p1",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox["\[Sigma]", 
+       RowBox[{
+        FormBox[
+         FormBox["\[Mu]",
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox[
+         FormBox[
+          RowBox[{
+           FormBox["p1",
+            TraditionalForm], "-", 
+           FormBox["p2",
+            TraditionalForm]}],
+          TraditionalForm],
+         TraditionalForm]}]], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["5",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p2",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "-", "m2"}]]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8065104762950087`*^9, 3.806510482098774*^9}},
+ CellLabel->"Out[33]=",
+ CellID->1802324926]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"FCSetDiracGammaScheme", "[", "\"\<BMHV\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.806510488808024*^9, 3.806510492390156*^9}},
+ CellLabel->"In[34]:=",
+ CellID->1620604391],
+
+Cell[BoxData[
+ FormBox["\<\"BMHV\"\>", TraditionalForm]], "Output",
+ CellChangeTimes->{3.80651049279187*^9},
+ CellLabel->"Out[34]=",
+ CellID->2094585895]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GordonSimplify", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[35]:=",
+ CellID->148568495],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    FractionBox[
+     RowBox[{"\[ImaginaryI]", " ", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           FormBox["p1",
+            TraditionalForm]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m1",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}], ".", 
+       SuperscriptBox["\[Sigma]", 
+        RowBox[{
+         FormBox[
+          FormBox["\[Mu]",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox[
+           RowBox[{
+            FormBox["p1",
+             TraditionalForm], "-", 
+            FormBox["p2",
+             TraditionalForm]}],
+           TraditionalForm],
+          TraditionalForm]}]], ".", 
+       SuperscriptBox[
+        OverscriptBox["\[Gamma]", "_"], 
+        FormBox["5",
+         TraditionalForm]], ".", 
+       RowBox[{"(", 
+        RowBox[{
+         FormBox["\<\"\[CurlyPhi]\"\>",
+          TraditionalForm], 
+         FormBox["\<\"(\"\>",
+          TraditionalForm], 
+         FormBox[
+          RowBox[{"-", 
+           FormBox["p2",
+            TraditionalForm]}],
+          TraditionalForm], 
+         FormBox["\<\",\"\>",
+          TraditionalForm], 
+         FormBox["m2",
+          TraditionalForm], 
+         FormBox["\<\")\"\>",
+          TraditionalForm]}], ")"}]}]}], 
+     RowBox[{"m1", "-", "m2"}]]}], "-", 
+   FractionBox[
+    RowBox[{
+     SuperscriptBox[
+      RowBox[{"(", 
+       FormBox[
+        FormBox[
+         RowBox[{
+          FormBox["p1",
+           TraditionalForm], "+", 
+          FormBox["p2",
+           TraditionalForm]}],
+         TraditionalForm],
+        TraditionalForm], ")"}], 
+      FormBox[
+       FormBox["\[Mu]",
+        TraditionalForm],
+       TraditionalForm]], " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p1",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["5",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p2",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "-", "m2"}]], "+", 
+   FractionBox[
+    RowBox[{"2", " ", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p1",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m1",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox["\[Gamma]", 
+       FormBox[
+        FormBox["\[Mu]",
+         TraditionalForm],
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        OverscriptBox["\[Gamma]", "^"], "\[CenterDot]", 
+        FormBox[
+         OverscriptBox[
+          FormBox["p2",
+           TraditionalForm], "^"],
+         TraditionalForm]}], ")"}], ".", 
+      SuperscriptBox[
+       OverscriptBox["\[Gamma]", "_"], 
+       FormBox["5",
+        TraditionalForm]], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        FormBox["\<\"\[CurlyPhi]\"\>",
+         TraditionalForm], 
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         RowBox[{"-", 
+          FormBox["p2",
+           TraditionalForm]}],
+         TraditionalForm], 
+        FormBox["\<\",\"\>",
+         TraditionalForm], 
+        FormBox["m2",
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], ")"}]}]}], 
+    RowBox[{"m1", "-", "m2"}]]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.806510496543885*^9},
+ CellLabel->"Out[35]=",
+ CellID->454355993]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More Examples", "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Scope", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1293636265],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Generalizations & Extensions", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1020263627],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["Options", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2061341341],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1757724783],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Applications", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->258228157],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Properties & Relations", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2123667759],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Possible Issues", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1305812373],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Interactive Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1653164318],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Neat Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+},
+WindowSize->{700, 770},
+WindowMargins->{{Automatic, 856}, {Automatic, 187}},
+CellContext->"Global`",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
+StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
+  CharacterEncoding -> "UTF-8"]
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "ExtendedExamples"->{
+  Cell[51561, 1983, 100, 2, 42, "ExtendedExamplesSection",
+   CellTags->"ExtendedExamples",
+   CellID->1854448968]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"ExtendedExamples", 53476, 2053}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 325, 14, 19, "History",
+ CellID->1247902091],
+Cell[CellGroupData[{
+Cell[908, 38, 68, 1, 22, "CategorizationSection",
+ CellID->1122911449],
+Cell[979, 41, 79, 2, 70, "Categorization",
+ CellID->686433507],
+Cell[1061, 45, 81, 2, 70, "Categorization",
+ CellID->605800465],
+Cell[1145, 49, 78, 2, 70, "Categorization",
+ CellID->468444828],
+Cell[1226, 53, 72, 1, 70, "Categorization"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1335, 59, 55, 1, 15, "KeywordsSection",
+ CellID->477174294],
+Cell[1393, 62, 45, 1, 70, "Keywords",
+ CellID->1164421360]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1475, 68, 65, 1, 15, "TemplatesSection",
+ CellID->1872225408],
+Cell[1543, 71, 94, 2, 70, "Template",
+ CellID->1562036412],
+Cell[1640, 75, 82, 2, 70, "Template",
+ CellID->158391909],
+Cell[1725, 79, 81, 2, 70, "Template",
+ CellID->1360575930],
+Cell[1809, 83, 82, 2, 70, "Template",
+ CellID->793782254]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1928, 90, 53, 1, 15, "DetailsSection",
+ CellID->307771771],
+Cell[1984, 93, 63, 2, 70, "Details",
+ CellID->670882175],
+Cell[2050, 97, 69, 2, 70, "Details",
+ CellID->350963985],
+Cell[2122, 101, 64, 2, 70, "Details",
+ CellID->8391405],
+Cell[2189, 105, 69, 2, 70, "Details",
+ CellID->3610269],
+Cell[2261, 109, 61, 2, 70, "Details",
+ CellID->401364205],
+Cell[2325, 113, 61, 2, 70, "Details",
+ CellID->350204745],
+Cell[2389, 117, 63, 2, 70, "Details",
+ CellID->732958810],
+Cell[2455, 121, 78, 2, 70, "Details",
+ CellID->222905350],
+Cell[2536, 125, 67, 2, 70, "Details",
+ CellID->240026365]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[2640, 132, 57, 1, 48, "ObjectName",
+ CellID->1224892054],
+Cell[2700, 135, 337, 8, 69, "Usage",
+ CellID->982511436],
+Cell[CellGroupData[{
+Cell[3062, 147, 182, 4, 20, "Input",
+ CellID->250226562],
+Cell[3247, 153, 1739, 45, 126, "Output",
+ CellID->1383488355]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5035, 204, 57, 1, 35, "TutorialsSection",
+ CellID->250839057],
+Cell[5095, 207, 45, 1, 15, "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5177, 213, 83, 1, 25, "RelatedDemonstrationsSection",
+ CellID->1268215905],
+Cell[5263, 216, 58, 1, 15, "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5358, 222, 65, 1, 25, "RelatedLinksSection",
+ CellID->1584193535],
+Cell[5426, 225, 49, 1, 15, "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5512, 231, 55, 1, 25, "SeeAlsoSection",
+ CellID->1255426704],
+Cell[5570, 234, 444, 17, 15, "SeeAlso",
+ CellID->655647701]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[6051, 256, 57, 1, 25, "MoreAboutSection",
+ CellID->38303248],
+Cell[6111, 259, 46, 1, 15, "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[6194, 265, 356, 11, 53, "PrimaryExamplesSection",
+ CellID->880084151],
+Cell[CellGroupData[{
+Cell[6575, 280, 324, 9, 20, "Input",
+ CellID->356943878],
+Cell[6902, 291, 628, 24, 19, "Output",
+ CellID->1292223288]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[7567, 320, 177, 4, 20, "Input",
+ CellID->1614855230],
+Cell[7747, 326, 3100, 115, 84, "Output",
+ CellID->1149611235]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[10884, 446, 349, 10, 20, "Input",
+ CellID->893086721],
+Cell[11236, 458, 767, 30, 22, "Output",
+ CellID->1800667857]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[12040, 493, 112, 3, 20, "Input",
+ CellID->1556234510],
+Cell[12155, 498, 3360, 125, 85, "Output",
+ CellID->493727217]
+}, Open  ]],
+Cell[15530, 626, 228, 6, 19, "Notes",
+ CellID->1261016597],
+Cell[CellGroupData[{
+Cell[15783, 636, 351, 10, 20, "Input",
+ CellID->981235250],
+Cell[16137, 648, 792, 31, 21, "Output",
+ CellID->593365759]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[16966, 684, 111, 3, 20, "Input",
+ CellID->508620888],
+Cell[17080, 689, 4798, 175, 124, "Output",
+ CellID->488903717]
+}, Open  ]],
+Cell[21893, 867, 201, 3, 19, "Notes",
+ CellID->599661764],
+Cell[CellGroupData[{
+Cell[22119, 874, 381, 11, 20, "Input",
+ CellID->1978201776],
+Cell[22503, 887, 766, 30, 21, "Output",
+ CellID->283459477]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[23306, 922, 113, 3, 20, "Input",
+ CellID->1305963384],
+Cell[23422, 927, 1273, 51, 24, "Output",
+ CellID->204342930]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[24732, 983, 491, 14, 35, "Input",
+ CellID->590788495],
+Cell[25226, 999, 4800, 175, 124, "Output",
+ CellID->947732373]
+}, Open  ]],
+Cell[30041, 1177, 340, 7, 32, "Notes",
+ CellID->806789778],
+Cell[CellGroupData[{
+Cell[30406, 1188, 465, 13, 34, "Input",
+ CellID->60397023],
+Cell[30874, 1203, 4800, 175, 124, "Output",
+ CellID->2054711607]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[35711, 1383, 466, 13, 34, "Input",
+ CellID->1605787920],
+Cell[36180, 1398, 4774, 175, 124, "Output",
+ CellID->918758801]
+}, Open  ]],
+Cell[40969, 1576, 225, 5, 19, "Notes",
+ CellID->1055202867],
+Cell[CellGroupData[{
+Cell[41219, 1585, 382, 11, 20, "Input",
+ CellID->1907110618],
+Cell[41604, 1598, 798, 33, 22, "Output",
+ CellID->1393611744]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[42439, 1636, 182, 4, 20, "Input",
+ CellID->1967420182],
+Cell[42624, 1642, 152, 4, 19, "Output",
+ CellID->538351384]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[42813, 1651, 179, 4, 20, "Input",
+ CellID->2132799337],
+Cell[42995, 1657, 3253, 120, 81, "Output",
+ CellID->1802324926]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[46285, 1782, 196, 4, 20, "Input",
+ CellID->1620604391],
+Cell[46484, 1788, 153, 4, 19, "Output",
+ CellID->2094585895]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[46674, 1797, 112, 3, 20, "Input",
+ CellID->148568495],
+Cell[46789, 1802, 4723, 175, 125, "Output",
+ CellID->454355993]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[51561, 1983, 100, 2, 42, "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+Cell[51664, 1987, 125, 3, 25, "ExampleSection",
+ CellID->1293636265],
+Cell[51792, 1992, 148, 3, 17, "ExampleSection",
+ CellID->1020263627],
+Cell[CellGroupData[{
+Cell[51965, 1999, 127, 3, 17, "ExampleSection",
+ CellID->2061341341],
+Cell[52095, 2004, 130, 3, 70, "ExampleSubsection",
+ CellID->1757724783],
+Cell[52228, 2009, 130, 3, 70, "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+Cell[52373, 2015, 131, 3, 17, "ExampleSection",
+ CellID->258228157],
+Cell[52507, 2020, 142, 3, 17, "ExampleSection",
+ CellID->2123667759],
+Cell[52652, 2025, 135, 3, 17, "ExampleSection",
+ CellID->1305812373],
+Cell[52790, 2030, 140, 3, 17, "ExampleSection",
+ CellID->1653164318],
+Cell[52933, 2035, 132, 3, 17, "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+}
+]
+*)
+

--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/SpinorChainEvaluate.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/SpinorChainEvaluate.nb
@@ -1,0 +1,728 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 10.4' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     17466,        718]
+NotebookOptionsPosition[     11834,        513]
+NotebookOutlinePosition[     12688,        545]
+CellTagsIndexPosition[     12577,        539]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[TextData[{
+ "New in: ",
+ Cell["9.3", "HistoryData",
+  CellTags->"New"],
+ " | Modified in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Modified"],
+ " | Obsolete in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Obsolete"],
+ " | Excised in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Excised"]
+}], "History",
+ CellID->1247902091],
+
+Cell[CellGroupData[{
+
+Cell["Categorization", "CategorizationSection",
+ CellID->1122911449],
+
+Cell["Symbol", "Categorization",
+ CellLabel->"Entity Type",
+ CellID->686433507],
+
+Cell["FeynCalc", "Categorization",
+ CellLabel->"Paclet Name",
+ CellID->605800465],
+
+Cell["FeynCalc`", "Categorization",
+ CellLabel->"Context",
+ CellID->468444828],
+
+Cell["FeynCalc/ref/SpinorChainEvaluate", "Categorization",
+ CellLabel->"URI"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Keywords", "KeywordsSection",
+ CellID->477174294],
+
+Cell["XXXX", "Keywords",
+ CellID->1164421360]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Syntax Templates", "TemplatesSection",
+ CellID->1872225408],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Additional Function Template",
+ CellID->1562036412],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Arguments Pattern",
+ CellID->158391909],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Local Variables",
+ CellID->1360575930],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Color Equal Signs",
+ CellID->793782254]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Details", "DetailsSection",
+ CellID->307771771],
+
+Cell["XXXX", "Details",
+ CellLabel->"Lead",
+ CellID->670882175],
+
+Cell["XXXX", "Details",
+ CellLabel->"Developers",
+ CellID->350963985],
+
+Cell["XXXX", "Details",
+ CellLabel->"Authors",
+ CellID->8391405],
+
+Cell["XXXX", "Details",
+ CellLabel->"Feature Name",
+ CellID->3610269],
+
+Cell["XXXX", "Details",
+ CellLabel->"QA",
+ CellID->401364205],
+
+Cell["XXXX", "Details",
+ CellLabel->"DA",
+ CellID->350204745],
+
+Cell["XXXX", "Details",
+ CellLabel->"Docs",
+ CellID->732958810],
+
+Cell["XXXX", "Details",
+ CellLabel->"Features Page Notes",
+ CellID->222905350],
+
+Cell["XXXX", "Details",
+ CellLabel->"Comments",
+ CellID->240026365]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["SpinorChainEvaluate", "ObjectName",
+ CellID->1224892054],
+
+Cell[TextData[{
+ Cell["   ", "ModInfo"],
+ Cell[BoxData[
+  RowBox[{"SpinorChainEvaluate", "[", "exp", "]"}]], "InlineFormula"],
+ "  explicitly evaluates suitable spinor chains, i.e. replaces a \
+DOT[Spinor[...],...,Spinor[...]] with a scalar quantity without a DOT."
+}], "Usage",
+ CellChangeTimes->{{3.808934973429956*^9, 3.80893500202831*^9}},
+ CellID->982511436],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Options", "[", "SpinorChainEvaluate", "]"}]], "Input",
+ CellChangeTimes->{3.80893498065347*^9},
+ CellTags->"DiracSimplify",
+ CellLabel->"In[9]:=",
+ CellID->2098245619],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"{", 
+   RowBox[{
+    RowBox[{"Collecting", "\[Rule]", "True"}], ",", 
+    RowBox[{"DiracSpinorNormalization", "\[Rule]", "\<\"Relativistic\"\>"}], 
+    ",", 
+    RowBox[{"FeynCalcExternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FeynCalcInternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FCVerbose", "\[Rule]", "False"}], ",", 
+    RowBox[{"Factoring", "\[Rule]", 
+     RowBox[{"{", 
+      RowBox[{"Factor2", ",", "5000"}], "}"}]}], ",", 
+    RowBox[{"TimeConstrained", "\[Rule]", "3"}]}], "}"}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.808934981622307*^9},
+ CellTags->"DiracSimplify",
+ CellLabel->"Out[9]=",
+ CellID->1393665166]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Tutorials", "TutorialsSection",
+ CellID->250839057],
+
+Cell["XXXX", "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Demonstrations", "RelatedDemonstrationsSection",
+ CellID->1268215905],
+
+Cell["XXXX", "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Links", "RelatedLinksSection",
+ CellID->1584193535],
+
+Cell["XXXX", "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["See Also", "SeeAlsoSection",
+ CellID->1255426704],
+
+Cell["XXXX", "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More About", "MoreAboutSection",
+ CellID->38303248],
+
+Cell["XXXX", "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[GridBox[{
+    {
+     StyleBox["Examples", "PrimaryExamplesSection"], 
+     ButtonBox[
+      RowBox[{
+       RowBox[{"More", " ", "Examples"}], " ", "\[RightTriangle]"}],
+      BaseStyle->"ExtendedExamplesLink",
+      ButtonData:>"ExtendedExamples"]}
+   }],
+  $Line = 0; Null]], "PrimaryExamplesSection",
+ CellID->880084151],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{"SpinorUBar", "[", 
+    RowBox[{"p", ",", "m"}], "]"}], ".", 
+   RowBox[{"SpinorU", "[", 
+    RowBox[{"p", ",", "m"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.808935015220194*^9, 3.808935036387856*^9}},
+ CellLabel->"In[11]:=",
+ CellID->1582941381],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    OverscriptBox["u", "_"], "(", 
+    FormBox["p",
+     TraditionalForm], ",", 
+    FormBox["m",
+     TraditionalForm], ")"}], ".", 
+   RowBox[{"u", "(", 
+    FormBox["p",
+     TraditionalForm], ",", 
+    FormBox["m",
+     TraditionalForm], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.808935027136505*^9, 3.8089350370725327`*^9}},
+ CellLabel->"Out[11]=",
+ CellID->1274886545]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"SpinorChainEvaluate", "[", "ex", "]"}]], "Input",
+ CellChangeTimes->{{3.808935028299223*^9, 3.80893504074244*^9}},
+ CellLabel->"In[12]:=",
+ CellID->1746417023],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"2", " ", "m"}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935041420594*^9},
+ CellLabel->"Out[12]=",
+ CellID->289307048]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"SpinorChainEvaluate", "[", 
+  RowBox[{"ex", ",", 
+   RowBox[{
+   "DiracSpinorNormalization", "\[Rule]", "\"\<Nonrelativistic\>\""}]}], 
+  "]"}]], "Input",
+ CellChangeTimes->{{3.808935044215845*^9, 3.808935057220467*^9}},
+ CellLabel->"In[13]:=",
+ CellID->1866439958],
+
+Cell[BoxData[
+ FormBox[
+  FractionBox["m", 
+   SuperscriptBox[
+    FormBox[
+     FormBox[
+      FormBox["p",
+       TraditionalForm],
+      TraditionalForm],
+     TraditionalForm], "0"]], TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935057665436*^9},
+ CellLabel->"Out[13]=",
+ CellID->851447209]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"SpinorChainEvaluate", "[", 
+  RowBox[{"ex", ",", 
+   RowBox[{"DiracSpinorNormalization", "\[Rule]", "\"\<Rest\>\""}]}], 
+  "]"}]], "Input",
+ CellChangeTimes->{{3.808935063306448*^9, 3.808935063966042*^9}},
+ CellLabel->"In[14]:=",
+ CellID->481248992],
+
+Cell[BoxData[
+ FormBox["1", TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935064264469*^9},
+ CellLabel->"Out[14]=",
+ CellID->505303537]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{"SpinorUBarD", "[", 
+    RowBox[{"p", ",", "m"}], "]"}], ".", 
+   RowBox[{"GA", "[", "5", "]"}], ".", 
+   RowBox[{"SpinorUD", "[", 
+    RowBox[{"p", ",", "m"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.80893507315722*^9, 3.808935077810277*^9}},
+ CellLabel->"In[15]:=",
+ CellID->1905916629],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   FormBox[
+    RowBox[{
+     OverscriptBox["u", "_"], "(", 
+     FormBox["p",
+      TraditionalForm], ",", 
+     FormBox["m",
+      TraditionalForm], ")"}],
+    TraditionalForm], ".", 
+   FormBox[
+    SuperscriptBox[
+     OverscriptBox["\[Gamma]", "_"], 
+     FormBox["5",
+      TraditionalForm]],
+    TraditionalForm], ".", 
+   FormBox[
+    RowBox[{"u", "(", 
+     FormBox["p",
+      TraditionalForm], ",", 
+     FormBox["m",
+      TraditionalForm], ")"}],
+    TraditionalForm]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935083007333*^9},
+ CellLabel->"Out[15]=",
+ CellID->557088443]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"SpinorChainEvaluate", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[16]:=",
+ CellID->1045403733],
+
+Cell[BoxData[
+ FormBox["0", TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935083634164*^9},
+ CellLabel->"Out[16]=",
+ CellID->633907994]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"FCSetDiracGammaScheme", "[", "\"\<BMHV\>\"", "]"}]], "Input",
+ CellChangeTimes->{{3.808935086052917*^9, 3.80893509038512*^9}},
+ CellLabel->"In[17]:=",
+ CellID->45938772],
+
+Cell[BoxData[
+ FormBox["\<\"BMHV\"\>", TraditionalForm]], "Output",
+ CellChangeTimes->{3.8089350908397512`*^9},
+ CellLabel->"Out[17]=",
+ CellID->850811358]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"SpinorChainEvaluate", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[18]:=",
+ CellID->249791036],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      FormBox["p",
+       TraditionalForm],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}], ".", 
+   SuperscriptBox[
+    OverscriptBox["\[Gamma]", "_"], 
+    FormBox["5",
+     TraditionalForm]], ".", 
+   RowBox[{"(", 
+    RowBox[{
+     FormBox["\<\"\[CurlyPhi]\"\>",
+      TraditionalForm], 
+     FormBox["\<\"(\"\>",
+      TraditionalForm], 
+     FormBox[
+      FormBox["p",
+       TraditionalForm],
+      TraditionalForm], 
+     FormBox["\<\",\"\>",
+      TraditionalForm], 
+     FormBox["m",
+      TraditionalForm], 
+     FormBox["\<\")\"\>",
+      TraditionalForm]}], ")"}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{3.808935091592018*^9},
+ CellLabel->"Out[18]=",
+ CellID->1783654565]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More Examples", "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Scope", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1293636265],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Generalizations & Extensions", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1020263627],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["Options", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2061341341],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1757724783],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Applications", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->258228157],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Properties & Relations", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2123667759],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Possible Issues", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1305812373],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Interactive Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1653164318],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Neat Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+},
+WindowSize->{700, 770},
+WindowMargins->{{679, Automatic}, {Automatic, 278}},
+CellContext->"Global`",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
+StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
+  CharacterEncoding -> "UTF-8"]
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "DiracSimplify"->{
+  Cell[3098, 147, 191, 5, 20, "Input",
+   CellTags->"DiracSimplify",
+   CellID->2098245619],
+  Cell[3292, 154, 680, 18, 50, "Output",
+   CellTags->"DiracSimplify",
+   CellID->1393665166]},
+ "ExtendedExamples"->{
+  Cell[10314, 455, 100, 2, 42, "ExtendedExamplesSection",
+   CellTags->"ExtendedExamples",
+   CellID->1854448968]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"DiracSimplify", 12226, 525},
+ {"ExtendedExamples", 12438, 532}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 325, 14, 19, "History",
+ CellID->1247902091],
+Cell[CellGroupData[{
+Cell[908, 38, 68, 1, 22, "CategorizationSection",
+ CellID->1122911449],
+Cell[979, 41, 79, 2, 70, "Categorization",
+ CellID->686433507],
+Cell[1061, 45, 81, 2, 70, "Categorization",
+ CellID->605800465],
+Cell[1145, 49, 78, 2, 70, "Categorization",
+ CellID->468444828],
+Cell[1226, 53, 77, 1, 70, "Categorization"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1340, 59, 55, 1, 15, "KeywordsSection",
+ CellID->477174294],
+Cell[1398, 62, 45, 1, 70, "Keywords",
+ CellID->1164421360]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1480, 68, 65, 1, 15, "TemplatesSection",
+ CellID->1872225408],
+Cell[1548, 71, 94, 2, 70, "Template",
+ CellID->1562036412],
+Cell[1645, 75, 82, 2, 70, "Template",
+ CellID->158391909],
+Cell[1730, 79, 81, 2, 70, "Template",
+ CellID->1360575930],
+Cell[1814, 83, 82, 2, 70, "Template",
+ CellID->793782254]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1933, 90, 53, 1, 15, "DetailsSection",
+ CellID->307771771],
+Cell[1989, 93, 63, 2, 70, "Details",
+ CellID->670882175],
+Cell[2055, 97, 69, 2, 70, "Details",
+ CellID->350963985],
+Cell[2127, 101, 64, 2, 70, "Details",
+ CellID->8391405],
+Cell[2194, 105, 69, 2, 70, "Details",
+ CellID->3610269],
+Cell[2266, 109, 61, 2, 70, "Details",
+ CellID->401364205],
+Cell[2330, 113, 61, 2, 70, "Details",
+ CellID->350204745],
+Cell[2394, 117, 63, 2, 70, "Details",
+ CellID->732958810],
+Cell[2460, 121, 78, 2, 70, "Details",
+ CellID->222905350],
+Cell[2541, 125, 67, 2, 70, "Details",
+ CellID->240026365]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[2645, 132, 62, 1, 48, "ObjectName",
+ CellID->1224892054],
+Cell[2710, 135, 363, 8, 56, "Usage",
+ CellID->982511436],
+Cell[CellGroupData[{
+Cell[3098, 147, 191, 5, 20, "Input",
+ CellTags->"DiracSimplify",
+ CellID->2098245619],
+Cell[3292, 154, 680, 18, 50, "Output",
+ CellTags->"DiracSimplify",
+ CellID->1393665166]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4021, 178, 57, 1, 35, "TutorialsSection",
+ CellID->250839057],
+Cell[4081, 181, 45, 1, 15, "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4163, 187, 83, 1, 25, "RelatedDemonstrationsSection",
+ CellID->1268215905],
+Cell[4249, 190, 58, 1, 15, "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4344, 196, 65, 1, 25, "RelatedLinksSection",
+ CellID->1584193535],
+Cell[4412, 199, 49, 1, 15, "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4498, 205, 55, 1, 25, "SeeAlsoSection",
+ CellID->1255426704],
+Cell[4556, 208, 43, 1, 15, "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4636, 214, 57, 1, 25, "MoreAboutSection",
+ CellID->38303248],
+Cell[4696, 217, 46, 1, 15, "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4779, 223, 356, 11, 53, "PrimaryExamplesSection",
+ CellID->880084151],
+Cell[CellGroupData[{
+Cell[5160, 238, 307, 9, 20, "Input",
+ CellID->1582941381],
+Cell[5470, 249, 439, 16, 19, "Output",
+ CellID->1274886545]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5946, 270, 183, 4, 20, "Input",
+ CellID->1746417023],
+Cell[6132, 276, 165, 5, 19, "Output",
+ CellID->289307048]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[6334, 286, 289, 8, 34, "Input",
+ CellID->1866439958],
+Cell[6626, 296, 302, 12, 38, "Output",
+ CellID->851447209]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[6965, 313, 273, 7, 20, "Input",
+ CellID->481248992],
+Cell[7241, 322, 142, 4, 19, "Output",
+ CellID->505303537]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[7420, 331, 348, 10, 20, "Input",
+ CellID->1905916629],
+Cell[7771, 343, 632, 26, 22, "Output",
+ CellID->557088443]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[8440, 374, 118, 3, 20, "Input",
+ CellID->1045403733],
+Cell[8561, 379, 142, 4, 19, "Output",
+ CellID->633907994]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[8740, 388, 193, 4, 20, "Input",
+ CellID->45938772],
+Cell[8936, 394, 155, 4, 19, "Output",
+ CellID->850811358]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[9128, 403, 117, 3, 20, "Input",
+ CellID->249791036],
+Cell[9248, 408, 1017, 41, 22, "Output",
+ CellID->1783654565]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[10314, 455, 100, 2, 42, "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+Cell[10417, 459, 125, 3, 25, "ExampleSection",
+ CellID->1293636265],
+Cell[10545, 464, 148, 3, 17, "ExampleSection",
+ CellID->1020263627],
+Cell[CellGroupData[{
+Cell[10718, 471, 127, 3, 17, "ExampleSection",
+ CellID->2061341341],
+Cell[10848, 476, 130, 3, 70, "ExampleSubsection",
+ CellID->1757724783],
+Cell[10981, 481, 130, 3, 70, "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+Cell[11126, 487, 131, 3, 17, "ExampleSection",
+ CellID->258228157],
+Cell[11260, 492, 142, 3, 17, "ExampleSection",
+ CellID->2123667759],
+Cell[11405, 497, 135, 3, 17, "ExampleSection",
+ CellID->1305812373],
+Cell[11543, 502, 140, 3, 17, "ExampleSection",
+ CellID->1653164318],
+Cell[11686, 507, 132, 3, 17, "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+}
+]
+*)
+
+(* End of internal cache information *)
+

--- a/FeynCalc/Feynman/ToStandardMatrixElement.m
+++ b/FeynCalc/Feynman/ToStandardMatrixElement.m
@@ -33,29 +33,31 @@ Begin["`ToStandardMatrixElement`Private`"]
 tsmeVerbose::usage="";
 
 Options[ToStandardMatrixElement] = {
-	CartesianIndex			-> False,
-	CartesianIndexNames		-> {},
-	ChangeDimension 		-> False,
-	ClearHeads				-> {StandardMatrixElement},
-	DiracOrder 				-> True,
-	DiracSimplify			-> True,
-	DiracEquation			-> True,
-	DiracSubstitute5 		-> True,
-	DiracSubstitute67 		-> False,
-	ExceptHeads				-> {},
-	FCColorIsolate 			-> True,
-	FCDiracIsolate 			-> True,
-	FCE 					-> False,
-	FCI 					-> False,
-	FCVerbose 				-> False,
-	Factoring 				-> {Factor, 5000},
-	LorentzIndex			-> False,
-	LorentzIndexNames		-> {},
-	Polarization 			-> True,
-	SirlinSimplify 			-> False,
-	Spinor 					-> False,
-	SpinorChainChiralSplit	-> True,
-	TimeConstrained 		-> 3
+	CartesianIndex				-> False,
+	CartesianIndexNames			-> {},
+	ChangeDimension 			-> False,
+	ClearHeads					-> {StandardMatrixElement},
+	DiracOrder 					-> True,
+	DiracSimplify				-> True,
+	DiracSpinorNormalization	-> "Relativistic",
+	DiracEquation				-> True,
+	DiracSubstitute5 			-> True,
+	DiracSubstitute67 			-> False,
+	ExceptHeads					-> {},
+	FCColorIsolate 				-> True,
+	FCDiracIsolate 				-> True,
+	FCE 						-> False,
+	FCI 						-> False,
+	FCVerbose 					-> False,
+	Factoring 					-> {Factor, 5000},
+	LorentzIndex				-> False,
+	LorentzIndexNames			-> {},
+	Polarization 				-> True,
+	SirlinSimplify 				-> False,
+	Spinor 						-> False,
+	SpinorChainChiralSplit		-> True,
+	SpinorChainEvaluate			-> True,
+	TimeConstrained 			-> 3
 }
 
 standmat/:
@@ -98,7 +100,8 @@ ToStandardMatrixElement[expr_/;Head[expr]=!=List, OptionsPattern[]]:=
 			ex = DiracSimplify[ex, FCI->True, DiracOrder->OptionValue[DiracOrder], DiracSubstitute67->OptionValue[DiracSubstitute67],
 				DiracSubstitute5->OptionValue[DiracSubstitute5], SirlinSimplify->OptionValue[SirlinSimplify],
 				DiracEquation->OptionValue[DiracEquation], LorentzIndexNames-> OptionValue[LorentzIndexNames],
-				CartesianIndexNames-> OptionValue[CartesianIndexNames]];
+				CartesianIndexNames-> OptionValue[CartesianIndexNames], SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+				DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[1, "ToStandardMatrixElement: DiracSimplify done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->tsmeVerbose];
 			FCPrint[3, "ToStandardMatrixElement: After DiracSimplify: ", ex, FCDoControl->tsmeVerbose]
 		];

--- a/FeynCalc/LoopIntegrals/FCMultiLoopTID.m
+++ b/FeynCalc/LoopIntegrals/FCMultiLoopTID.m
@@ -42,19 +42,21 @@ Begin["`FCMultiLoopTID`Private`"]
 mltidVerbose::usage="";
 
 Options[FCMultiLoopTID] = {
-	ApartFF				-> True,
-	Collecting			-> True,
-	Contract			-> True,
-	Dimension			-> D,
-	DiracSimplify		-> True,
-	ExpandScalarProduct -> True,
-	Factoring 			-> {Factor2, 5000},
-	FCE					-> False,
-	FCI					-> False,
-	FCVerbose			-> False,
-	FDS					-> True,
-	TimeConstrained		-> 3,
-	Uncontract			-> {Polarization}
+	ApartFF						-> True,
+	Collecting					-> True,
+	Contract					-> True,
+	Dimension					-> D,
+	DiracSimplify				-> True,
+	DiracSpinorNormalization	-> "Relativistic",
+	ExpandScalarProduct			-> True,
+	Factoring 					-> {Factor2, 5000},
+	FCE							-> False,
+	FCI							-> False,
+	FCVerbose					-> False,
+	FDS							-> True,
+	SpinorChainEvaluate			-> True,
+	TimeConstrained				-> 3,
+	Uncontract					-> {Polarization}
 };
 
 FCMultiLoopTID[expr_List, qs_List/; FreeQ[qs, OptionQ], opts:OptionsPattern[]] :=
@@ -113,7 +115,8 @@ FCMultiLoopTID[expr_/;Head[expr]=!=List, qs_List/; FreeQ[qs, OptionQ], OptionsPa
 		If[	OptionValue[DiracSimplify] && !FreeQ2[ex,{DiracGamma,DiracSigma,Spinor}],
 			time=AbsoluteTime[];
 			FCPrint[1, "FCMultiLoopTID: Applying DiracSimplify.", FCDoControl->mltidVerbose];
-			ex = DiracSimplify[ex, FCI->True];
+			ex = DiracSimplify[ex, FCI->True, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+				DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[3,"FCMultiLoopTID: After DiracSimplify: ", ex, FCDoControl->mltidVerbose];
 			FCPrint[1, "FCMultiLoopTID: Done applying DiracSimplify, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->mltidVerbose]
 		];

--- a/FeynCalc/LoopIntegrals/OneLoopSimplify.m
+++ b/FeynCalc/LoopIntegrals/OneLoopSimplify.m
@@ -44,21 +44,23 @@ Begin["`OneLoopSimplify`Private`"]
 olsVerbose::usage="";
 
 Options[OneLoopSimplify] = {
-	Collecting 			-> True,
-	Dimension 			-> D,
-	DiracSimplify 		-> True,
-	ExpandScalarProduct -> True,
-	FCE 				-> False,
-	FCI 				-> False,
-	FCVerbose 			-> False,
-	Factoring 			-> Automatic,
-	FinalSubstitutions	-> {},
-	OPE1Loop			-> False,
-	PowerSimplify		-> True,
-	SUNNToCACF			-> True,
-	SUNTrace			-> False,
-	ToPaVe				-> False,
-	UsePaVeBasis		-> False
+	Collecting 					-> True,
+	Dimension 					-> D,
+	DiracSimplify 				-> True,
+	DiracSpinorNormalization	-> "Relativistic",
+	ExpandScalarProduct 		-> True,
+	FCE 						-> False,
+	FCI 						-> False,
+	FCVerbose 					-> False,
+	Factoring 					-> Automatic,
+	FinalSubstitutions			-> {},
+	OPE1Loop					-> False,
+	PowerSimplify				-> True,
+	SpinorChainEvaluate 		-> True,
+	SUNNToCACF					-> True,
+	SUNTrace					-> False,
+	ToPaVe						-> False,
+	UsePaVeBasis				-> False
 };
 
 (*Do we really need to support this syntax???*)
@@ -153,7 +155,8 @@ OneLoopSimplify[expr_, qu_, OptionsPattern[]] :=
 		If[	!FreeQ2[tmp, FeynCalc`Package`DiracHeadsList] && optDiracSimplify,
 			time=AbsoluteTime[];
 			FCPrint[1, "OneLoopSimplify: Applying DiracSimplify.", FCDoControl->olsVerbose];
-			tmp = DiracSimplify[tmp, FCI->True];
+			tmp = DiracSimplify[tmp, FCI->True, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+				DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[1, "OneLoopSimplify: DiracSimplify done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->olsVerbose];
 			FCPrint[3, "OneLoopSimplify: After DiracSimplify: ", tmp, FCDoControl->olsVerbose]
 		];
@@ -177,7 +180,8 @@ OneLoopSimplify[expr_, qu_, OptionsPattern[]] :=
 
 		time=AbsoluteTime[];
 		FCPrint[1, "OneLoopSimplify: Applying TID.", FCDoControl->olsVerbose];
-		tmp =  TID[tmp,  q, Dimension -> dim, FCI->True, DiracSimplify -> optDiracSimplify, ToPaVe->OptionValue[ToPaVe], UsePaVeBasis->OptionValue[UsePaVeBasis]];
+		tmp =  TID[tmp,  q, Dimension -> dim, FCI->True, DiracSimplify -> optDiracSimplify, ToPaVe->OptionValue[ToPaVe], UsePaVeBasis->OptionValue[UsePaVeBasis],
+				SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate], DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 		FCPrint[1, "OneLoopSimplify: TID done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->olsVerbose];
 		FCPrint[3, "OneLoopSimplify: After TID: ", tmp, FCDoControl->olsVerbose];
 
@@ -189,7 +193,8 @@ OneLoopSimplify[expr_, qu_, OptionsPattern[]] :=
 		If[	!FreeQ2[tmp, FeynCalc`Package`DiracHeadsList] && optDiracSimplify,
 			time=AbsoluteTime[];
 			FCPrint[1, "OneLoopSimplify: Applying DiracSimplify.", FCDoControl->olsVerbose];
-			tmp = DiracSimplify[tmp, FCI->True];
+			tmp = DiracSimplify[tmp, FCI->True, SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate],
+				DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[1, "OneLoopSimplify: DiracSimplify done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->olsVerbose];
 			FCPrint[3, "OneLoopSimplify: After DiracSimplify: ", tmp, FCDoControl->olsVerbose]
 		];

--- a/FeynCalc/LoopIntegrals/TID.m
+++ b/FeynCalc/LoopIntegrals/TID.m
@@ -79,6 +79,7 @@ Options[TID] = {
 	Contract 								-> True,
 	Dimension 								-> D,
 	DiracSimplify 							-> True,
+	DiracSpinorNormalization				-> "Relativistic",
 	DiracTrace 								-> True,
 	EpsEvaluate								-> True,
 	ExpandScalarProduct						-> True,
@@ -154,8 +155,6 @@ TID[am_/;Head[am]=!=List , q_/; Head[q]=!=List, OptionsPattern[]] :=
 		pavear 			= OptionValue[PaVeAutoReduce];
 		genpave 		= OptionValue[GenPaVe];
 
-		(* Multiply the input expression by the prefactor *)
-		t0 = OptionValue[Prefactor] t0;
 
 		If[ FreeQ[t0,q],
 			Return[t0]
@@ -218,7 +217,8 @@ TID[am_/;Head[am]=!=List , q_/; Head[q]=!=List, OptionsPattern[]] :=
 		If[	OptionValue[DiracSimplify] && !FreeQ2[t0,{DiracGamma,DiracSigma,Spinor}],
 			FCPrint[1, "TID: Applying DiracSimplify.", FCDoControl->tidVerbose];
 			time=AbsoluteTime[];
-			t0 = DiracSimplify[t0,FCI->True, DiracTraceEvaluate->OptionValue[DiracTrace], Expand2->False];
+			t0 = DiracSimplify[t0,FCI->True, DiracTraceEvaluate->OptionValue[DiracTrace], Expand2->False,
+				SpinorChainEvaluate -> OptionValue[SpinorChainEvaluate], DiracSpinorNormalization -> OptionValue[DiracSpinorNormalization]];
 			FCPrint[1, "TID: Done applying DiracSimplify, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->tidVerbose];
 			FCPrint[3, "TID: After DiracSimplify: ", t0 , FCDoControl->tidVerbose]
 		];

--- a/FeynCalc/Shared/SharedOptions.m
+++ b/FeynCalc/Shared/SharedOptions.m
@@ -46,6 +46,17 @@ DiracIndexNames::usage =
 and other functions. It renames the generic dummy Dirac indices to the indices \
 in the supplied list.";
 
+DiracSpinorNormalization::usage=
+"DiracSpinorNormalization is an option for SpinorChainEvaluate, DiracSimplify and other \
+functions. It specifies the normalization of the spinor inner products ubar(p).u(p)
+and vbar(p).v(p). Following values are supported: \n
+
+\"Relativistic\" - this is the standard value corresponding to ubar(p).u(p) = 2m,
+vbar(p).v(p) =  -2m. \n
+\"Rest\" - this sets ubar(p).u(p) = 1, vbar(p).v(p) = -1. \n
+\"Nonrelativistic\" - this sets ubar(p).u(p) = m/p^0, vbar(p).v(p) = -m/p^0. \n
+.";
+
 DiracTraceEvaluate::usage =
 "DiracTraceEvaluate is an option for DiracTrace, DiracSimplify and \
 some other functions. If set to False, Dirac traces remain unevaluated.";

--- a/Tests/Dirac/Dirac.mt
+++ b/Tests/Dirac/Dirac.mt
@@ -82,6 +82,12 @@ If[ Names["Tests`Dirac`fcstSirlinSimplify*"]=!={},
 	tmpTest = tmpTest /. testID->TestID /. test -> Test;
 ];
 
+If[ Names["Tests`Dirac`fcstGordonSimplify*"]=!={},
+	tmpTest = Map[test[ToExpression[(#[[2]])],ToExpression[(#[[3]])],testID->#[[1]]]&,
+	Join@@(ToExpression/@Names["Tests`Dirac`fcstGordonSimplify*"])];
+	tmpTest = tmpTest /. testID->TestID /. test -> Test;
+];
+
 If[ Names["Tests`Dirac`fcstChisholm*"]=!={},
 	tmpTest = Map[test[ToExpression[(#[[2]])],ToExpression[(#[[3]])],testID->#[[1]]]&,
 	Join@@(ToExpression/@Names["Tests`Dirac`fcstChisholm*"])];

--- a/Tests/Dirac/Dirac.mt
+++ b/Tests/Dirac/Dirac.mt
@@ -131,6 +131,14 @@ If[ Names["Tests`Dirac`fcstDiracChainExpand*"]=!={},
 	tmpTest = tmpTest /. testID->TestID /. test -> Test;
 ];
 
+FCSetDiracGammaScheme["NDR"];
+
+If[ Names["Tests`Dirac`fcstDiracChainExplicit*"]=!={},
+	tmpTest = Map[test[ToExpression[(#[[2]])],ToExpression[(#[[3]])],testID->#[[1]]]&,
+	Join@@(ToExpression/@Names["Tests`Dirac`fcstDiracChainExplicit*"])];
+	tmpTest = tmpTest /. testID->TestID /. test -> Test;
+];
+
 If[ Names["Tests`Dirac`fcstDiracChainFactor*"]=!={},
 	tmpTest = Map[test[ToExpression[(#[[2]])],ToExpression[(#[[3]])],testID->#[[1]]]&,
 	Join@@(ToExpression/@Names["Tests`Dirac`fcstDiracChainFactor*"])];

--- a/Tests/Dirac/DiracChainEvaluate.test
+++ b/Tests/Dirac/DiracChainEvaluate.test
@@ -1,0 +1,328 @@
+
+
+(* :Title: DiracChainExplicit.test										*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for DiracChainExplicit	*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`Dirac`fcstDiracChainExplicit =
+({
+{"fcstSpinorChainEvaluate-ID1", "SpinorChainEvaluate[0]", "0"},
+{"fcstSpinorChainEvaluate-ID2", "SpinorChainEvaluate[x]", "x"},
+{"fcstSpinorChainEvaluate-ID3",
+"SpinorChainEvaluate[x+GA[mu].SpinorU[p,m]]",
+"x + DiracGamma[LorentzIndex[mu]] . Spinor[Momentum[p], m, 1]"},
+{"fcstSpinorChainEvaluate-ID4",
+"SpinorChainEvaluate[SpinorUBar[p].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID5",
+"SpinorChainEvaluate[SpinorVBar[p].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID6",
+"SpinorChainEvaluate[SpinorUBar[p].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID7",
+"SpinorChainEvaluate[SpinorVBar[p].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID8",
+"SpinorChainEvaluate[SpinorUBar[p,m].SpinorU[p,m]]", "2*m"},
+{"fcstSpinorChainEvaluate-ID9",
+"SpinorChainEvaluate[SpinorVBar[p,m].SpinorV[p,m]]", "-2*m"},
+{"fcstSpinorChainEvaluate-ID10",
+"SpinorChainEvaluate[SpinorUBar[p,m].SpinorV[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID11",
+"SpinorChainEvaluate[SpinorVBar[p,m].SpinorU[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID12",
+"SpinorChainEvaluate[SpinorUBar[p,m1].SpinorU[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . Spinor[Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID13",
+"SpinorChainEvaluate[SpinorVBar[p,m1].SpinorV[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . Spinor[-Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID14",
+"SpinorChainEvaluate[SpinorUBar[p,m1].SpinorV[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . Spinor[-Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID15",
+"SpinorChainEvaluate[SpinorVBar[p,m1].SpinorU[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . Spinor[Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID16",
+"SpinorChainEvaluate[SpinorUBarD[p].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID17",
+"SpinorChainEvaluate[SpinorVBarD[p].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID18",
+"SpinorChainEvaluate[SpinorUBarD[p].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID19",
+"SpinorChainEvaluate[SpinorVBarD[p].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID20",
+"SpinorChainEvaluate[SpinorUBarD[p,m].SpinorUD[p,m]]", "2*m"},
+{"fcstSpinorChainEvaluate-ID21",
+"SpinorChainEvaluate[SpinorVBarD[p,m].SpinorVD[p,m]]", "-2*m"},
+{"fcstSpinorChainEvaluate-ID22",
+"SpinorChainEvaluate[SpinorUBarD[p,m].SpinorVD[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID23",
+"SpinorChainEvaluate[SpinorVBarD[p,m].SpinorUD[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID24",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].SpinorUD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID25",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].SpinorVD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . Spinor[-Momentum[p, D], m2, \
+1]"},
+{"fcstSpinorChainEvaluate-ID26",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].SpinorVD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID27",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].SpinorUD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID28",
+"SpinorChainEvaluate[SpinorUBar[p].GA[5].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID29",
+"SpinorChainEvaluate[SpinorVBar[p].GA[5].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID30",
+"SpinorChainEvaluate[SpinorUBar[p].GA[5].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID31",
+"SpinorChainEvaluate[SpinorVBar[p].GA[5].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID32",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[5].SpinorU[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID33",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[5].SpinorV[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID34",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[5].SpinorV[p,m]]",
+"Spinor[Momentum[p], m, 1] . DiracGamma[5] . Spinor[-Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID35",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[5].SpinorU[p,m]]",
+"Spinor[-Momentum[p], m, 1] . DiracGamma[5] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID36",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[5].SpinorU[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[5] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID37",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[5].SpinorV[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[5] . \
+Spinor[-Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID38",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[5].SpinorV[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[5] . Spinor[-Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID39",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[5].SpinorU[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[5] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID40",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[5].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID41",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[5].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID42",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[5].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID43",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[5].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID44",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[5].SpinorUD[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID45",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[5].SpinorVD[p,m]]", "0"},
+{"fcstSpinorChainEvaluate-ID46",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[5].SpinorVD[p,m]]",
+"Spinor[Momentum[p, D], m, 1] . DiracGamma[5] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID47",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[5].SpinorUD[p,m]]",
+"Spinor[-Momentum[p, D], m, 1] . DiracGamma[5] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID48",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[5].SpinorUD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[5] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID49",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[5].SpinorVD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[5] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID50",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[5].SpinorVD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[5] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID51",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[5].SpinorUD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[5] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID52",
+"SpinorChainEvaluate[SpinorUBar[p].GA[6].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID53",
+"SpinorChainEvaluate[SpinorVBar[p].GA[6].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID54",
+"SpinorChainEvaluate[SpinorUBar[p].GA[6].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID55",
+"SpinorChainEvaluate[SpinorVBar[p].GA[6].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID56",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[6].SpinorU[p,m]]",
+"Spinor[Momentum[p], m, 1] . DiracGamma[6] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID57",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[6].SpinorV[p,m]]",
+"Spinor[-Momentum[p], m, 1] . DiracGamma[6] . Spinor[-Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID58",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[6].SpinorV[p,m]]",
+"Spinor[Momentum[p], m, 1] . DiracGamma[6] . Spinor[-Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID59",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[6].SpinorU[p,m]]",
+"Spinor[-Momentum[p], m, 1] . DiracGamma[6] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID60",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[6].SpinorU[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[6] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID61",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[6].SpinorV[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[6] . \
+Spinor[-Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID62",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[6].SpinorV[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[6] . Spinor[-Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID63",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[6].SpinorU[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[6] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID64",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[6].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID65",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[6].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID66",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[6].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID67",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[6].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID68",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[6].SpinorUD[p,m]]",
+"Spinor[Momentum[p, D], m, 1] . DiracGamma[6] . Spinor[Momentum[p, \
+D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID69",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[6].SpinorVD[p,m]]",
+"Spinor[-Momentum[p, D], m, 1] . DiracGamma[6] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID70",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[6].SpinorVD[p,m]]",
+"Spinor[Momentum[p, D], m, 1] . DiracGamma[6] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID71",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[6].SpinorUD[p,m]]",
+"Spinor[-Momentum[p, D], m, 1] . DiracGamma[6] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID72",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[6].SpinorUD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[6] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID73",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[6].SpinorVD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[6] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID74",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[6].SpinorVD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[6] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID75",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[6].SpinorUD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[6] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID76",
+"SpinorChainEvaluate[SpinorUBar[p].GA[7].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID77",
+"SpinorChainEvaluate[SpinorVBar[p].GA[7].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID78",
+"SpinorChainEvaluate[SpinorUBar[p].GA[7].SpinorV[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID79",
+"SpinorChainEvaluate[SpinorVBar[p].GA[7].SpinorU[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID80",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[7].SpinorU[p,m]]",
+"Spinor[Momentum[p], m, 1] . DiracGamma[7] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID81",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[7].SpinorV[p,m]]",
+"Spinor[-Momentum[p], m, 1] . DiracGamma[7] . Spinor[-Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID82",
+"SpinorChainEvaluate[SpinorUBar[p,m].GA[7].SpinorV[p,m]]",
+"Spinor[Momentum[p], m, 1] . DiracGamma[7] . Spinor[-Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID83",
+"SpinorChainEvaluate[SpinorVBar[p,m].GA[7].SpinorU[p,m]]",
+"Spinor[-Momentum[p], m, 1] . DiracGamma[7] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstSpinorChainEvaluate-ID84",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[7].SpinorU[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[7] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID85",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[7].SpinorV[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[7] . \
+Spinor[-Momentum[p], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID86",
+"SpinorChainEvaluate[SpinorUBar[p,m1].GA[7].SpinorV[p,m2]]",
+"Spinor[Momentum[p], m1, 1] . DiracGamma[7] . Spinor[-Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID87",
+"SpinorChainEvaluate[SpinorVBar[p,m1].GA[7].SpinorU[p,m2]]",
+"Spinor[-Momentum[p], m1, 1] . DiracGamma[7] . Spinor[Momentum[p], \
+m2, 1]"},
+{"fcstSpinorChainEvaluate-ID88",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[7].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID89",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[7].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID90",
+"SpinorChainEvaluate[SpinorUBarD[p].GA[7].SpinorVD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID91",
+"SpinorChainEvaluate[SpinorVBarD[p].GA[7].SpinorUD[p]]", "0"},
+{"fcstSpinorChainEvaluate-ID92",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[7].SpinorUD[p,m]]",
+"Spinor[Momentum[p, D], m, 1] . DiracGamma[7] . Spinor[Momentum[p, \
+D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID93",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[7].SpinorVD[p,m]]",
+"Spinor[-Momentum[p, D], m, 1] . DiracGamma[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID94",
+"SpinorChainEvaluate[SpinorUBarD[p,m].GA[7].SpinorVD[p,m]]",
+"Spinor[Momentum[p, D], m, 1] . DiracGamma[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID95",
+"SpinorChainEvaluate[SpinorVBarD[p,m].GA[7].SpinorUD[p,m]]",
+"Spinor[-Momentum[p, D], m, 1] . DiracGamma[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstSpinorChainEvaluate-ID96",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[7].SpinorUD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[7] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID97",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[7].SpinorVD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[7] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID98",
+"SpinorChainEvaluate[SpinorUBarD[p,m1].GA[7].SpinorVD[p,m2]]",
+"Spinor[Momentum[p, D], m1, 1] . DiracGamma[7] . \
+Spinor[-Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID99",
+"SpinorChainEvaluate[SpinorVBarD[p,m1].GA[7].SpinorUD[p,m2]]",
+"Spinor[-Momentum[p, D], m1, 1] . DiracGamma[7] . \
+Spinor[Momentum[p, D], m2, 1]"},
+{"fcstSpinorChainEvaluate-ID100",
+"SpinorChainEvaluate[SpinorUBar[p,m].SpinorU[p,m],\
+DiracSpinorNormalization\[Rule]\"Nonrelativistic\"]",
+"m/TemporalPair[ExplicitLorentzIndex[0], TemporalMomentum[p]]"},
+{"fcstSpinorChainEvaluate-ID101",
+"SpinorChainEvaluate[SpinorUBar[p,m].SpinorU[p,m],\
+DiracSpinorNormalization\[Rule]\"Rest\"]", "1"},
+{"fcstSpinorChainEvaluate-ID102",
+"SpinorChainEvaluate[SpinorVBar[p,m].SpinorV[p,m],\
+DiracSpinorNormalization\[Rule]\"Nonrelativistic\"]",
+"-(m/TemporalPair[ExplicitLorentzIndex[0], \
+TemporalMomentum[p]])"},
+{"fcstSpinorChainEvaluate-ID103",
+"SpinorChainEvaluate[SpinorVBar[p,m].SpinorV[p,m],\
+DiracSpinorNormalization\[Rule]\"Rest\"]", "-1"},
+{"fcstSpinorChainEvaluate-ID104", Null, "Null"}
+});

--- a/Tests/Dirac/DiracSimplify.test
+++ b/Tests/Dirac/DiracSimplify.test
@@ -227,7 +227,13 @@ Spinor[-Momentum[p1, D], mb, 1].GAD[i1].GAD[i2].GAD[i3].GAD[i4].GAD[
 "{GA[mu] SP[p, p], 2 FV[p, mu] GS[p] - GA[mu] SP[p, p]}"},
 {"fcstDiracSimplify-ID46",
 "DiracSimplify[GAD[mu].(GSD[p + q] + m).GAD[mu],FCE->True]",
-"D m + 2 GSD[p] - D GSD[p] + 2 GSD[q] - D GSD[q]"}
+"D m + 2 GSD[p] - D GSD[p] + 2 GSD[q] - D GSD[q]"},
+{"fcstDiracSimplify-ID47",
+"DiracSimplify[
+x SpinorUBarD[p].GAD[mu].SpinorUD[p] + y SpinorUBarD[p].SpinorUD[p],
+SpinorChainEvaluate -> False, FCE -> True]",
+"y Spinor[Momentum[p, D], 0, 1].Spinor[Momentum[p, D], 0, 1] +
+x Spinor[Momentum[p, D], 0, 1].GAD[mu].Spinor[Momentum[p, D], 0, 1]"}
 };
 
 

--- a/Tests/Dirac/GordonSimplify.test
+++ b/Tests/Dirac/GordonSimplify.test
@@ -1,0 +1,2693 @@
+
+
+(* :Title: GordonSimplify.test												*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for GordonSimplify			*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`Dirac`fcstGordonSimplify =
+{
+{"fcstGordonSimplify-ID1", "GordonSimplify[0]", "0"},
+{"fcstGordonSimplify-ID2",
+"GordonSimplify[SpinorUBar[p1,m1].GS[p].SpinorU[p2,m2],FCE\[Rule]\
+True]", "(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GS[p], GS[p1 - \
+p2]] . Spinor[Momentum[p2], m2, 1])/(m1 + m2) + (Spinor[Momentum[p1], \
+m1, 1] . Spinor[Momentum[p2], m2, 1]*SP[p, p1 + p2])/(m1 + m2)"},
+{"fcstGordonSimplify-ID3",
+"GordonSimplify[SpinorUBar[p1,m1].CGA[i].SpinorU[p2,m2],FCE\[Rule]\
+True]", "(CV[p1 + p2, i]*Spinor[Momentum[p1], m1, 1] . \
+Spinor[Momentum[p2], m2, 1])/(m1 + m2) + (I*Spinor[Momentum[p1], m1, \
+1] . DiracSigma[CGA[i], GS[p1 - p2]] . Spinor[Momentum[p2], m2, \
+1])/(m1 + m2)"},
+{"fcstGordonSimplify-ID4",
+"GordonSimplify[SpinorUBar[p1,m1].CGS[p].SpinorU[p2,m2],FCE\[Rule]\
+True]", "(CSP[p, p1 + p2]*Spinor[Momentum[p1], m1, 1] . \
+Spinor[Momentum[p2], m2, 1])/(m1 + m2) + (I*Spinor[Momentum[p1], m1, \
+1] . DiracSigma[CGS[p], GS[p1 - p2]] . Spinor[Momentum[p2], m2, \
+1])/(m1 + m2)"},
+{"fcstGordonSimplify-ID5",
+"GordonSimplify[SpinorUBar[p1,m].GA[mu,5].SpinorV[p2,m]SpinorVBar[\
+q1,m].GA[mu,5].SpinorU[q2,m],FCE\[Rule]True]",
+"(((I/2)*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2], m, 1])/m + (Spinor[Momentum[p1], \
+m, 1] . GA[5] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, \
+mu])/(2*m))*(((-I/2)*Spinor[-Momentum[q1], m, 1] . DiracSigma[GA[mu], \
+GS[q1 - q2]] . GA[5] . Spinor[Momentum[q2], m, 1])/m - \
+(Spinor[-Momentum[q1], m, 1] . GA[5] . Spinor[Momentum[q2], m, \
+1]*FV[q1 + q2, mu])/(2*m))"},
+{"fcstGordonSimplify-ID6",
+"GordonSimplify[-Spinor[Momentum[p2,D],ME,1].GAD[Lor1].Spinor[\
+Momentum[p1,D],ME,1] \
+(x1)+Spinor[Momentum[p2,D],ME,1].Spinor[Momentum[p1,D],ME,1] \
+(FVD[p1,Lor1]+FVD[p2,Lor1]) x2,FCE\[Rule]True]",
+"x2*Spinor[Momentum[p2, D], ME, 1] . Spinor[Momentum[p1, D], ME, \
+1]*(FVD[p1, Lor1] + FVD[p2, Lor1]) - x1*(((I/2)*Spinor[Momentum[p2, \
+D], ME, 1] . DiracSigma[GAD[Lor1], GSD[-p1 + p2]] . \
+Spinor[Momentum[p1, D], ME, 1])/ME + (Spinor[Momentum[p2, D], ME, 1] \
+. Spinor[Momentum[p1, D], ME, 1]*FVD[p1 + p2, Lor1])/(2*ME))"}
+};
+
+Tests`Dirac`fcstGordonSimplifyGenericGeneric =
+({
+{"fcstGordonSimplifyGenericGeneric-ID1",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu].SpinorU[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[Momentum[p2], m2, 1])/(m1 + m2) + (Spinor[Momentum[p1], m1, \
+1] . Spinor[Momentum[p2], m2, 1]*FV[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGenericGeneric-ID2",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu].SpinorV[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[-Momentum[p2], m2, 1])/(m1 + m2) - \
+(Spinor[-Momentum[p1], m1, 1] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + \
+p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGenericGeneric-ID3",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu].SpinorV[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[-Momentum[p2], m2, 1])/(m1 - m2) + (Spinor[Momentum[p1], m1, \
+1] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGenericGeneric-ID4",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu].SpinorU[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[Momentum[p2], m2, 1])/(m1 - m2) - \
+(Spinor[-Momentum[p1], m1, 1] . Spinor[Momentum[p2], m2, 1]*FV[p1 + \
+p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID5",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu].SpinorU[p2,m],FCE->True]",
+	"((I/2)*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[Momentum[p2], m, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID6",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu].SpinorV[p2,m],FCE->True]",
+	"((-I/2)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[-Momentum[p2], m, 1])/m - (Spinor[-Momentum[p1], m, 1] \
+. Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID7",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu].SpinorV[p2,m],FCE->True]",
+	"Spinor[Momentum[p1], m, 1] . GA[mu] . Spinor[-Momentum[p2], m, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID8",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu].SpinorU[p2,m],FCE->True]",
+	"Spinor[-Momentum[p1], m, 1] . GA[mu] . Spinor[Momentum[p2], m, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID9",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu].SpinorU[p2,m],FCE->True]",
+	"(I*Spinor[Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[Momentum[p2], m, 1])/m + (Spinor[Momentum[p1], 0, 1] . \
+Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID10",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu].SpinorV[p2,m],FCE->True]",
+	"((-I)*Spinor[-Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[-Momentum[p2], m, 1])/m - (Spinor[-Momentum[p1], 0, 1] \
+. Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID11",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu].SpinorV[p2,m],FCE->True]",
+	"((-I)*Spinor[Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[-Momentum[p2], m, 1])/m - (Spinor[Momentum[p1], 0, 1] . \
+Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID12",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu].SpinorU[p2,m],FCE->True]",
+	"(I*Spinor[-Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[Momentum[p2], m, 1])/m + (Spinor[-Momentum[p1], 0, 1] . \
+Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID13",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu].SpinorU[p2,0],FCE->True]",
+	"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID14",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu].SpinorV[p2,0],FCE->True]",
+	"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[-Momentum[p2], 0, 1])/m - (Spinor[-Momentum[p1], m, 1] \
+. Spinor[-Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID15",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu].SpinorV[p2,0],FCE->True]",
+	"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. Spinor[-Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+Spinor[-Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID16",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu].SpinorU[p2,0],FCE->True]",
+	"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . Spinor[Momentum[p2], 0, 1])/m - (Spinor[-Momentum[p1], m, 1] . \
+Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID17",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu].SpinorU[p2,0],FCE->True]",
+	"Spinor[Momentum[p1], 0, 1] . GA[mu] . Spinor[Momentum[p2], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID18",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu].SpinorV[p2,0],FCE->True]",
+	"Spinor[-Momentum[p1], 0, 1] . GA[mu] . Spinor[-Momentum[p2], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID19",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu].SpinorV[p2,0],FCE->True]",
+	"Spinor[Momentum[p1], 0, 1] . GA[mu] . Spinor[-Momentum[p2], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID20",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu].SpinorU[p2,0],FCE->True]",
+	"Spinor[-Momentum[p1], 0, 1] . GA[mu] . Spinor[Momentum[p2], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID21",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu].SpinorU[p,m],FCE->True]",
+"(Spinor[Momentum[p], m, 1] . Spinor[Momentum[p], m, 1]*FV[p, \
+mu])/m"},
+{"fcstGordonSimplifyGeneric-ID22",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu].SpinorV[p,m],FCE->True]",
+"-((Spinor[-Momentum[p], m, 1] . Spinor[-Momentum[p], m, 1]*FV[p, \
+mu])/m)"},
+{"fcstGordonSimplifyGeneric-ID23",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu].SpinorV[p,m],FCE->True]",
+"Spinor[Momentum[p], m, 1] . GA[mu] . Spinor[-Momentum[p], m, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID24",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu].SpinorU[p,m],FCE->True]",
+"Spinor[-Momentum[p], m, 1] . GA[mu] . Spinor[Momentum[p], m, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID25",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu].SpinorU[p,0],FCE->True]",
+"Spinor[Momentum[p], 0, 1] . GA[mu] . Spinor[Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID26",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu].SpinorV[p,0],FCE->True]",
+"Spinor[-Momentum[p], 0, 1] . GA[mu] . Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID27",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu].SpinorV[p,0],FCE->True]",
+"Spinor[Momentum[p], 0, 1] . GA[mu] . Spinor[-Momentum[p], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID28",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu].SpinorU[p,0],FCE->True]",
+"Spinor[-Momentum[p], 0, 1] . GA[mu] . Spinor[Momentum[p], 0, \
+1]"},
+{"fcstGordonSimplifyGeneric-ID29",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,5].SpinorU[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[5] . Spinor[Momentum[p2], m2, 1])/(m1 - m2) + \
+(Spinor[Momentum[p1], m1, 1] . GA[5] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID30",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,5].SpinorV[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2], m2, 1])/(m1 - m2) - \
+(Spinor[-Momentum[p1], m1, 1] . GA[5] . Spinor[-Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID31",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,5].SpinorV[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[5] . Spinor[-Momentum[p2], m2, 1])/(m1 + m2) + \
+(Spinor[Momentum[p1], m1, 1] . GA[5] . Spinor[-Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID32",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,5].SpinorU[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2], m2, 1])/(m1 + m2) - \
+(Spinor[-Momentum[p1], m1, 1] . GA[5] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID33",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,5].SpinorU[p2,m],FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[5] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID34",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,5].SpinorV[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID35",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,5].SpinorV[p2,m],FCE->True]",
+"((I/2)*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2], m, 1])/m + (Spinor[Momentum[p1], \
+m, 1] . GA[5] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID36",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,5].SpinorU[p2,m],FCE->True]",
+"((-I/2)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2], m, 1])/m - (Spinor[-Momentum[p1], \
+m, 1] . GA[5] . Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID37",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,5].SpinorU[p2,m],FCE->True]",
+"((-I)*Spinor[Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2], m, 1])/m - (Spinor[Momentum[p1], \
+0, 1] . GA[5] . Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID38",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,5].SpinorV[p2,m],FCE->True]",
+"(I*Spinor[-Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[5] . Spinor[-Momentum[p2], m, 1])/m + (Spinor[-Momentum[p1], 0, \
+1] . GA[5] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID39",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,5].SpinorV[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[5] . Spinor[-Momentum[p2], m, 1])/m + (Spinor[Momentum[p1], 0, 1] \
+. GA[5] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID40",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,5].SpinorU[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], 0, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2], m, 1])/m - (Spinor[-Momentum[p1], \
+0, 1] . GA[5] . Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID41",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,5].SpinorU[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[5] . Spinor[Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+GA[5] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID42",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,5].SpinorV[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2], 0, 1])/m - \
+(Spinor[-Momentum[p1], m, 1] . GA[5] . Spinor[-Momentum[p2], 0, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID43",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,5].SpinorV[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[5] . Spinor[-Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] \
+. GA[5] . Spinor[-Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID44",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,5].SpinorU[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2], 0, 1])/m - (Spinor[-Momentum[p1], \
+m, 1] . GA[5] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID45",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,5].SpinorU[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[5] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID46",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,5].SpinorV[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID47",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,5].SpinorV[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID48",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,5].SpinorU[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[5] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID49",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,5].SpinorU[p,m],FCE->True]",
+	"Spinor[Momentum[p], m, 1] . GA[mu] . GA[5] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID50",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,5].SpinorV[p,m],FCE->True]",
+	"Spinor[-Momentum[p], m, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID51",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,5].SpinorV[p,m],FCE->True]",
+	"(Spinor[Momentum[p], m, 1] . GA[5] . Spinor[-Momentum[p], m, \
+1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID52",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,5].SpinorU[p,m],FCE->True]",
+	"-((Spinor[-Momentum[p], m, 1] . GA[5] . Spinor[Momentum[p], m, \
+1]*FV[p, mu])/m)"},
+{"fcstGordonSimplifyGeneric-ID53",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,5].SpinorU[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[5] . Spinor[Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID54",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,5].SpinorV[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID55",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,5].SpinorV[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[5] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID56",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,5].SpinorU[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[5] . \
+Spinor[Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID57",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,6].SpinorU[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[6] . Spinor[Momentum[p2], m2, 1])/m1 - (m2*Spinor[Momentum[p1], \
+m1, 1] . GA[mu] . GA[7] . Spinor[Momentum[p2], m2, 1])/m1 + \
+(Spinor[Momentum[p1], m1, 1] . GA[6] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID58",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,6].SpinorV[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2], m2, 1])/m1 - \
+(m2*Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m2, 1])/m1 - (Spinor[-Momentum[p1], m1, 1] . \
+GA[6] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID59",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,6].SpinorV[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[6] . Spinor[-Momentum[p2], m2, 1])/m1 + (m2*Spinor[Momentum[p1], \
+m1, 1] . GA[mu] . GA[7] . Spinor[-Momentum[p2], m2, 1])/m1 + \
+(Spinor[Momentum[p1], m1, 1] . GA[6] . Spinor[-Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID60",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,6].SpinorU[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2], m2, 1])/m1 + \
+(m2*Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m2, 1])/m1 - (Spinor[-Momentum[p1], m1, 1] . \
+GA[6] . Spinor[Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID61",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,6].SpinorU[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[6] . Spinor[Momentum[p2], m, 1])/m - Spinor[Momentum[p1], m, 1] . \
+GA[mu] . GA[7] . Spinor[Momentum[p2], m, 1] + (Spinor[Momentum[p1], \
+m, 1] . GA[6] . Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID62",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,6].SpinorV[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2], m, 1])/m - Spinor[-Momentum[p1], \
+m, 1] . GA[mu] . GA[7] . Spinor[-Momentum[p2], m, 1] - \
+(Spinor[-Momentum[p1], m, 1] . GA[6] . Spinor[-Momentum[p2], m, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID63",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,6].SpinorV[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[6] . Spinor[-Momentum[p2], m, 1])/m + Spinor[Momentum[p1], m, 1] . \
+GA[mu] . GA[7] . Spinor[-Momentum[p2], m, 1] + (Spinor[Momentum[p1], \
+m, 1] . GA[6] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID64",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,6].SpinorU[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2], m, 1])/m + Spinor[-Momentum[p1], \
+m, 1] . GA[mu] . GA[7] . Spinor[Momentum[p2], m, 1] - \
+(Spinor[-Momentum[p1], m, 1] . GA[6] . Spinor[Momentum[p2], m, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID65",
+"GordonSimplify[SpinorUBar[p1,m1]. GA[mu,6].SpinorU[p2,m2],Inverse\
+\[Rule]{m2},FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[7] . Spinor[Momentum[p2], m2, 1])/m2 - (m1*Spinor[Momentum[p1], \
+m1, 1] . GA[mu] . GA[7] . Spinor[Momentum[p2], m2, 1])/m2 + \
+(Spinor[Momentum[p1], m1, 1] . GA[7] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID66",
+"GordonSimplify[SpinorVBar[p1,m1]. GA[mu,6].SpinorV[p2,m2],Inverse\
+\[Rule]{m2},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2], m2, 1])/m2 - \
+(m1*Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m2, 1])/m2 - (Spinor[-Momentum[p1], m1, 1] . \
+GA[7] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID67",
+"GordonSimplify[SpinorUBar[p1,m1]. GA[mu,6].SpinorV[p2,m2],Inverse\
+\[Rule]{m2},FCE->True]",
+"((-I)*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2], m2, 1])/m2 + \
+(m1*Spinor[Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m2, 1])/m2 - (Spinor[Momentum[p1], m1, 1] . \
+GA[7] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID68",
+"GordonSimplify[SpinorVBar[p1,m1]. GA[mu,6].SpinorU[p2,m2],Inverse\
+\[Rule]{m2},FCE->True]",
+"(I*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[7] . Spinor[Momentum[p2], m2, 1])/m2 + (m1*Spinor[-Momentum[p1], \
+m1, 1] . GA[mu] . GA[7] . Spinor[Momentum[p2], m2, 1])/m2 + \
+(Spinor[-Momentum[p1], m1, 1] . GA[7] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID69",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,6].SpinorU[p2,m],Inverse\
+\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID70",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,6].SpinorV[p2,m],Inverse\
+\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID71",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,6].SpinorV[p2,m],Inverse\
+\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID72",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,6].SpinorU[p2,m],Inverse\
+\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID73",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,6].SpinorU[p2,m],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID74",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,6].SpinorV[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID75",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,6].SpinorV[p2,m],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID76",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,6].SpinorU[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID77",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,6].SpinorU[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[6] . Spinor[Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+GA[6] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID78",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,6].SpinorV[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2], 0, 1])/m - \
+(Spinor[-Momentum[p1], m, 1] . GA[6] . Spinor[-Momentum[p2], 0, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID79",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,6].SpinorV[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[6] . Spinor[-Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] \
+. GA[6] . Spinor[-Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID80",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,6].SpinorU[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2], 0, 1])/m - (Spinor[-Momentum[p1], \
+m, 1] . GA[6] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID81",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,6].SpinorU[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID82",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,6].SpinorV[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID83",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,6].SpinorV[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID84",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,6].SpinorU[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID85",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,6].SpinorU[p,m],FCE->True]",
+	"-Spinor[Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p], m, 1] + (2*Spinor[Momentum[p], m, 1] . GA[6] . \
+Spinor[Momentum[p], m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID86",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,6].SpinorV[p,m],FCE->True]",
+	"-Spinor[-Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], m, 1] - (2*Spinor[-Momentum[p], m, 1] . GA[6] . \
+Spinor[-Momentum[p], m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID87",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,6].SpinorV[p,m],FCE->True]",
+	"Spinor[Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], m, 1] + (2*Spinor[Momentum[p], m, 1] . GA[6] . \
+Spinor[-Momentum[p], m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID88",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,6].SpinorU[p,m],FCE->True]",
+	"Spinor[-Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p], m, 1] - (2*Spinor[-Momentum[p], m, 1] . GA[6] . \
+Spinor[Momentum[p], m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID89",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,6].SpinorU[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[6] . Spinor[Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID90",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,6].SpinorV[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID91",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,6].SpinorV[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID92",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,6].SpinorU[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID93",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,7].SpinorU[p2,m2],FCE->True]",
+"Spinor[Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID94",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,7].SpinorV[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID95",
+"GordonSimplify[SpinorUBar[p1,m1]. \
+GA[mu,7].SpinorV[p2,m2],FCE->True]",
+"Spinor[Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID96",
+"GordonSimplify[SpinorVBar[p1,m1]. \
+GA[mu,7].SpinorU[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID97",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,7].SpinorU[p2,m],FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID98",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,7].SpinorV[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID99",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,7].SpinorV[p2,m],FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID100",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,7].SpinorU[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID101",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,7].SpinorU[p2,m],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID102",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,7].SpinorV[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID103",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,7].SpinorV[p2,m],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID104",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,7].SpinorU[p2,m],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID105",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,7].SpinorU[p2,0],FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID106",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,7].SpinorV[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID107",
+"GordonSimplify[SpinorUBar[p1,m]. \
+GA[mu,7].SpinorV[p2,0],FCE->True]",
+"Spinor[Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID108",
+"GordonSimplify[SpinorVBar[p1,m]. \
+GA[mu,7].SpinorU[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID109",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,7].SpinorU[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID110",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,7].SpinorV[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID111",
+"GordonSimplify[SpinorUBar[p1,0]. \
+GA[mu,7].SpinorV[p2,0],FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID112",
+"GordonSimplify[SpinorVBar[p1,0]. \
+GA[mu,7].SpinorU[p2,0],FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID113",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,7].SpinorU[p,m],FCE->True]",
+	"Spinor[Momentum[p], m, 1] . GA[mu] . GA[7] . Spinor[Momentum[p], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID114",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,7].SpinorV[p,m],FCE->True]",
+	"Spinor[-Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID115",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,7].SpinorV[p,m],FCE->True]",
+	"Spinor[Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID116",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,7].SpinorU[p,m],FCE->True]",
+	"Spinor[-Momentum[p], m, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID117",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,7].SpinorU[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[7] . Spinor[Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID118",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,7].SpinorV[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID119",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,7].SpinorV[p,0],FCE->True]",
+	"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID120",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,7].SpinorU[p,0],FCE->True]",
+	"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID121",
+"GordonSimplify[SpinorUBar[p1,m1]. GA[mu,7].SpinorU[p2,m2],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[7] . Spinor[Momentum[p2], m2, 1])/m1 - (m2*Spinor[Momentum[p1], \
+m1, 1] . GA[mu] . GA[6] . Spinor[Momentum[p2], m2, 1])/m1 + \
+(Spinor[Momentum[p1], m1, 1] . GA[7] . Spinor[Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID122",
+"GordonSimplify[SpinorVBar[p1,m1]. GA[mu,7].SpinorV[p2,m2],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2], m2, 1])/m1 - \
+(m2*Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p2], m2, 1])/m1 - (Spinor[-Momentum[p1], m1, 1] . \
+GA[7] . Spinor[-Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID123",
+"GordonSimplify[SpinorUBar[p1,m1]. GA[mu,7].SpinorV[p2,m2],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - p2]] \
+. GA[7] . Spinor[-Momentum[p2], m2, 1])/m1 + (m2*Spinor[Momentum[p1], \
+m1, 1] . GA[mu] . GA[6] . Spinor[-Momentum[p2], m2, 1])/m1 + \
+(Spinor[Momentum[p1], m1, 1] . GA[7] . Spinor[-Momentum[p2], m2, \
+1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID124",
+"GordonSimplify[SpinorVBar[p1,m1]. GA[mu,7].SpinorU[p2,m2],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m1, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2], m2, 1])/m1 + \
+(m2*Spinor[-Momentum[p1], m1, 1] . GA[mu] . GA[6] . \
+Spinor[Momentum[p2], m2, 1])/m1 - (Spinor[-Momentum[p1], m1, 1] . \
+GA[7] . Spinor[Momentum[p2], m2, 1]*FV[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID125",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,7].SpinorU[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[7] . Spinor[Momentum[p2], m, 1])/m - Spinor[Momentum[p1], m, 1] . \
+GA[mu] . GA[6] . Spinor[Momentum[p2], m, 1] + (Spinor[Momentum[p1], \
+m, 1] . GA[7] . Spinor[Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID126",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,7].SpinorV[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2], m, 1])/m - Spinor[-Momentum[p1], \
+m, 1] . GA[mu] . GA[6] . Spinor[-Momentum[p2], m, 1] - \
+(Spinor[-Momentum[p1], m, 1] . GA[7] . Spinor[-Momentum[p2], m, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID127",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,7].SpinorV[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[7] . Spinor[-Momentum[p2], m, 1])/m + Spinor[Momentum[p1], m, 1] . \
+GA[mu] . GA[6] . Spinor[-Momentum[p2], m, 1] + (Spinor[Momentum[p1], \
+m, 1] . GA[7] . Spinor[-Momentum[p2], m, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID128",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,7].SpinorU[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2], m, 1])/m + Spinor[-Momentum[p1], \
+m, 1] . GA[mu] . GA[6] . Spinor[Momentum[p2], m, 1] - \
+(Spinor[-Momentum[p1], m, 1] . GA[7] . Spinor[Momentum[p2], m, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID129",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu,7].SpinorU[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID130",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu,7].SpinorV[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID131",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu,7].SpinorV[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID132",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu,7].SpinorU[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID133",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,7].SpinorU[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[7] . Spinor[Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] . \
+GA[7] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID134",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,7].SpinorV[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2], 0, 1])/m - \
+(Spinor[-Momentum[p1], m, 1] . GA[7] . Spinor[-Momentum[p2], 0, \
+1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID135",
+"GordonSimplify[SpinorUBar[p1,m]. GA[mu,7].SpinorV[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - p2]] . \
+GA[7] . Spinor[-Momentum[p2], 0, 1])/m + (Spinor[Momentum[p1], m, 1] \
+. GA[7] . Spinor[-Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID136",
+"GordonSimplify[SpinorVBar[p1,m]. GA[mu,7].SpinorU[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1], m, 1] . DiracSigma[GA[mu], GS[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2], 0, 1])/m - (Spinor[-Momentum[p1], \
+m, 1] . GA[7] . Spinor[Momentum[p2], 0, 1]*FV[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID137",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu,7].SpinorU[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID138",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu,7].SpinorV[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID139",
+"GordonSimplify[SpinorUBar[p1,0]. GA[mu,7].SpinorV[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID140",
+"GordonSimplify[SpinorVBar[p1,0]. GA[mu,7].SpinorU[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1], 0, 1] . GA[mu] . GA[7] . \
+Spinor[Momentum[p2], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID141",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,7].SpinorU[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"-Spinor[Momentum[p], m, 1] . GA[mu] . GA[6] . Spinor[Momentum[p], \
+m, 1] + (2*Spinor[Momentum[p], m, 1] . GA[7] . Spinor[Momentum[p], m, \
+1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID142",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,7].SpinorV[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"-Spinor[-Momentum[p], m, 1] . GA[mu] . GA[6] . \
+Spinor[-Momentum[p], m, 1] - (2*Spinor[-Momentum[p], m, 1] . GA[7] . \
+Spinor[-Momentum[p], m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID143",
+"GordonSimplify[SpinorUBar[p,m]. GA[mu,7].SpinorV[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p], m, 1] . GA[mu] . GA[6] . Spinor[-Momentum[p], \
+m, 1] + (2*Spinor[Momentum[p], m, 1] . GA[7] . Spinor[-Momentum[p], \
+m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID144",
+"GordonSimplify[SpinorVBar[p,m]. GA[mu,7].SpinorU[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p], m, 1] . GA[mu] . GA[6] . Spinor[Momentum[p], \
+m, 1] - (2*Spinor[-Momentum[p], m, 1] . GA[7] . Spinor[Momentum[p], \
+m, 1]*FV[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID145",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,7].SpinorU[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[7] . Spinor[Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID146",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,7].SpinorV[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[7] . \
+Spinor[-Momentum[p], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID147",
+"GordonSimplify[SpinorUBar[p,0]. GA[mu,7].SpinorV[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p], 0, 1] . GA[mu] . GA[7] . Spinor[-Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID148",
+"GordonSimplify[SpinorVBar[p,0]. GA[mu,7].SpinorU[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p], 0, 1] . GA[mu] . GA[7] . Spinor[Momentum[p], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID149",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu].SpinorUD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m2, 1])/(m1 + m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . Spinor[Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID150",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu].SpinorVD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[-Momentum[p2, D], m2, 1])/(m1 + m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . Spinor[-Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID151",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu].SpinorVD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[-Momentum[p2, D], m2, 1])/(m1 - m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . Spinor[-Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID152",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu].SpinorUD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[Momentum[p2, D], m2, 1])/(m1 - m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . Spinor[Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID153",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"((I/2)*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[Momentum[p1, D], \
+m, 1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID154",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I/2)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[-Momentum[p2, D], m, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . Spinor[-Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID155",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID156",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . Spinor[Momentum[p2, \
+D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID157",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[Momentum[p1, D], 0, \
+1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID158",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], m, 1])/m - (Spinor[-Momentum[p1, \
+D], 0, 1] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID159",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I)*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], m, 1])/m - (Spinor[Momentum[p1, D], \
+0, 1] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID160",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"(I*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[-Momentum[p1, D], \
+0, 1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID161",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], m, \
+1] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID162",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, \
+D], m, 1] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID163",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[-Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], \
+m, 1] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID164",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, D], \
+m, 1] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID165",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[Momentum[p2, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID166",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID167",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID168",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID169",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu].SpinorUD[p,m],FCE->True]",
+"(Spinor[Momentum[p, D], m, 1] . Spinor[Momentum[p, D], m, \
+1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID170",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu].SpinorVD[p,m],FCE->True]",
+"-((Spinor[-Momentum[p, D], m, 1] . Spinor[-Momentum[p, D], m, \
+1]*FVD[p, mu])/m)"},
+{"fcstGordonSimplifyGeneric-ID171",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID172",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID173",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID174",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID175",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID176",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID177",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,5].SpinorUD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2, D], m2, 1])/(m1 - m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . GA[5] . Spinor[Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID178",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,5].SpinorVD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[-Momentum[p2, D], m2, 1])/(m1 - m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . GA[5] . Spinor[-Momentum[p2, D], \
+m2, 1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID179",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,5].SpinorVD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m2, 1])/(m1 + m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . GA[5] . Spinor[-Momentum[p2, D], \
+m2, 1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID180",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,5].SpinorUD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[Momentum[p2, D], m2, 1])/(m1 + m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . GA[5] . Spinor[Momentum[p2, D], \
+m2, 1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID181",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID182",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID183",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"((I/2)*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[5] . Spinor[-Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID184",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I/2)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[5] . Spinor[Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID185",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I)*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m - \
+(Spinor[Momentum[p1, D], 0, 1] . GA[5] . Spinor[Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID186",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"(I*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m + \
+(Spinor[-Momentum[p1, D], 0, 1] . GA[5] . Spinor[-Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID187",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m + \
+(Spinor[Momentum[p1, D], 0, 1] . GA[5] . Spinor[-Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID188",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m - \
+(Spinor[-Momentum[p1, D], 0, 1] . GA[5] . Spinor[Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID189",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[5] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID190",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[-Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[5] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID191",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[5] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID192",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[5] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID193",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID194",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID195",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID196",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID197",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,5].SpinorUD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID198",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,5].SpinorVD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID199",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,5].SpinorVD[p,m],FCE->True]",
+"(Spinor[Momentum[p, D], m, 1] . GA[5] . Spinor[-Momentum[p, D], \
+m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID200",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,5].SpinorUD[p,m],FCE->True]",
+"-((Spinor[-Momentum[p, D], m, 1] . GA[5] . Spinor[Momentum[p, D], \
+m, 1]*FVD[p, mu])/m)"},
+{"fcstGordonSimplifyGeneric-ID201",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,5].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID202",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,5].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID203",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,5].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID204",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,5].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID205",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2, D], m2, 1])/m1 - \
+(m2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1])/m1 + (Spinor[Momentum[p1, D], m1, 1] \
+. GA[6] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID206",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[6] . Spinor[-Momentum[p2, D], m2, 1])/m1 - \
+(m2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1])/m1 - (Spinor[-Momentum[p1, D], m1, \
+1] . GA[6] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID207",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2, D], m2, 1])/m1 + \
+(m2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1])/m1 + (Spinor[Momentum[p1, D], m1, 1] \
+. GA[6] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID208",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[6] . Spinor[Momentum[p2, D], m2, 1])/m1 + \
+(m2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1])/m1 - (Spinor[-Momentum[p1, D], m1, 1] \
+. GA[6] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID209",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2, D], m, 1])/m - Spinor[Momentum[p1, \
+D], m, 1] . GAD[mu] . GA[7] . Spinor[Momentum[p2, D], m, 1] + \
+(Spinor[Momentum[p1, D], m, 1] . GA[6] . Spinor[Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID210",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[6] . Spinor[-Momentum[p2, D], m, 1])/m - \
+Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1] - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[6] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID211",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2, D], m, 1])/m + \
+Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1] + (Spinor[Momentum[p1, D], m, 1] . \
+GA[6] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID212",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[6] . Spinor[Momentum[p2, D], m, 1])/m + \
+Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1] - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[6] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID213",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID214",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID215",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID216",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID217",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2, D], m2, 1])/m2 - \
+(m1*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1])/m2 + (Spinor[Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID218",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[7] . Spinor[-Momentum[p2, D], m2, 1])/m2 - \
+(m1*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1])/m2 - (Spinor[-Momentum[p1, D], m1, \
+1] . GA[7] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID219",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"((-I)*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[7] . Spinor[-Momentum[p2, D], m2, 1])/m2 + \
+(m1*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1])/m2 - (Spinor[Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID220",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"(I*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2, D], m2, 1])/m2 + \
+(m1*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1])/m2 + (Spinor[-Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m2"},
+{"fcstGordonSimplifyGeneric-ID221",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID222",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID223",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID224",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID225",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[6] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID226",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[6] . Spinor[-Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[6] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID227",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[6] . Spinor[-Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[6] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID228",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[6] . Spinor[Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[6] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID229",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID230",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID231",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID232",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID233",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,6].SpinorUD[p,m],FCE->True]",
+"-Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1] + (2*Spinor[Momentum[p, D], m, 1] . \
+GA[6] . Spinor[Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID234",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,6].SpinorVD[p,m],FCE->True]",
+"-Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1] - (2*Spinor[-Momentum[p, D], m, 1] . \
+GA[6] . Spinor[-Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID235",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,6].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1] + (2*Spinor[Momentum[p, D], m, 1] . \
+GA[6] . Spinor[-Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID236",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,6].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1] - (2*Spinor[-Momentum[p, D], m, 1] . \
+GA[6] . Spinor[Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID237",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,6].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID238",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,6].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID239",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,6].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID240",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,6].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID241",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID242",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID243",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID244",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID245",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID246",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID247",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID248",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID249",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID250",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID251",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID252",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID253",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID254",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID255",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID256",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID257",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID258",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID259",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID260",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID261",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,7].SpinorUD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID262",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,7].SpinorVD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID263",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,7].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID264",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,7].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID265",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,7].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID266",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,7].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID267",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,7].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID268",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,7].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID269",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2, D], m2, 1])/m1 - \
+(m2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1])/m1 + (Spinor[Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID270",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[7] . Spinor[-Momentum[p2, D], m2, 1])/m1 - \
+(m2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1])/m1 - (Spinor[-Momentum[p1, D], m1, \
+1] . GA[7] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID271",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2, D], m2, 1])/m1 + \
+(m2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1])/m1 + (Spinor[Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID272",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[7] . Spinor[Momentum[p2, D], m2, 1])/m1 + \
+(m2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1])/m1 - (Spinor[-Momentum[p1, D], m1, 1] \
+. GA[7] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/m1"},
+{"fcstGordonSimplifyGeneric-ID273",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2, D], m, 1])/m - Spinor[Momentum[p1, \
+D], m, 1] . GAD[mu] . GA[6] . Spinor[Momentum[p2, D], m, 1] + \
+(Spinor[Momentum[p1, D], m, 1] . GA[7] . Spinor[Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID274",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[7] . Spinor[-Momentum[p2, D], m, 1])/m - \
+Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1] - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[7] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID275",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2, D], m, 1])/m + \
+Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1] + (Spinor[Momentum[p1, D], m, 1] . \
+GA[7] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID276",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[7] . Spinor[Momentum[p2, D], m, 1])/m + \
+Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1] - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[7] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID277",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID278",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID279",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID280",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID281",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[7] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID282",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[7] . Spinor[-Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[7] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID283",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[7] . Spinor[-Momentum[p2, D], 0, 1])/m + \
+(Spinor[Momentum[p1, D], m, 1] . GA[7] . Spinor[-Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID284",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[7] . Spinor[Momentum[p2, D], 0, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . GA[7] . Spinor[Momentum[p2, D], 0, \
+1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID285",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID286",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID287",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID288",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID289",
+"GordonSimplify[SpinorUBarD[p,m]. GAD[mu,7].SpinorUD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"-Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], m, 1] + (2*Spinor[Momentum[p, D], m, 1] . \
+GA[7] . Spinor[Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID290",
+"GordonSimplify[SpinorVBarD[p,m]. GAD[mu,7].SpinorVD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"-Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], m, 1] - (2*Spinor[-Momentum[p, D], m, 1] . \
+GA[7] . Spinor[-Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID291",
+"GordonSimplify[SpinorUBarD[p,m]. GAD[mu,7].SpinorVD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], m, 1] + (2*Spinor[Momentum[p, D], m, 1] . \
+GA[7] . Spinor[-Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID292",
+"GordonSimplify[SpinorVBarD[p,m]. GAD[mu,7].SpinorUD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], m, 1] - (2*Spinor[-Momentum[p, D], m, 1] . \
+GA[7] . Spinor[Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID293",
+"GordonSimplify[SpinorUBarD[p,0]. GAD[mu,7].SpinorUD[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID294",
+"GordonSimplify[SpinorVBarD[p,0]. GAD[mu,7].SpinorVD[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID295",
+"GordonSimplify[SpinorUBarD[p,0]. GAD[mu,7].SpinorVD[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}}]",
+"Spinor[Momentum[p, D], 0, 1] . DiracGamma[LorentzIndex[mu, D], D] \
+. DiracGamma[7] . Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID296",
+"FCSetDiracGammaScheme[\"BMHV\"]; \
+GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu].SpinorUD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m2, 1])/(m1 + m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . Spinor[Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID297",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu].SpinorVD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[-Momentum[p2, D], m2, 1])/(m1 + m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . Spinor[-Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID298",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu].SpinorVD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[-Momentum[p2, D], m2, 1])/(m1 - m2) + \
+(Spinor[Momentum[p1, D], m1, 1] . Spinor[-Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID299",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu].SpinorUD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[Momentum[p2, D], m2, 1])/(m1 - m2) - \
+(Spinor[-Momentum[p1, D], m1, 1] . Spinor[Momentum[p2, D], m2, \
+1]*FVD[p1 + p2, mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID300",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"((I/2)*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[Momentum[p1, D], \
+m, 1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID301",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I/2)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . Spinor[-Momentum[p2, D], m, 1])/m - \
+(Spinor[-Momentum[p1, D], m, 1] . Spinor[-Momentum[p2, D], m, \
+1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID302",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID303",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . Spinor[Momentum[p2, \
+D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID304",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[Momentum[p1, D], 0, \
+1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID305",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], m, 1])/m - (Spinor[-Momentum[p1, \
+D], 0, 1] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID306",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,m],FCE->True]",
+"((-I)*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], m, 1])/m - (Spinor[Momentum[p1, D], \
+0, 1] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID307",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,m],FCE->True]",
+"(I*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], m, 1])/m + (Spinor[-Momentum[p1, D], \
+0, 1] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID308",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], m, \
+1] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID309",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[-Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, \
+D], m, 1] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID310",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . Spinor[-Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], \
+m, 1] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID311",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . Spinor[Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, D], \
+m, 1] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID312",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[Momentum[p2, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID313",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID314",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID315",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . Spinor[Momentum[p2, \
+D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID316",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu].SpinorUD[p,m],FCE->True]",
+"(Spinor[Momentum[p, D], m, 1] . Spinor[Momentum[p, D], m, \
+1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID317",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu].SpinorVD[p,m],FCE->True]",
+"-((Spinor[-Momentum[p, D], m, 1] . Spinor[-Momentum[p, D], m, \
+1]*FVD[p, mu])/m)"},
+{"fcstGordonSimplifyGeneric-ID318",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID319",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+m, 1]"},
+{"fcstGordonSimplifyGeneric-ID320",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID321",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID322",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . Spinor[-Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID323",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . Spinor[Momentum[p, D], \
+0, 1]"},
+{"fcstGordonSimplifyGeneric-ID324",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,5].SpinorUD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2, D], m2, 1])/(m1 - m2) - \
+(2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], m2, 1])/(m1 - m2) + (Spinor[Momentum[p1, D], \
+m1, 1] . GA[5] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/(m1 \
+- m2)"},
+{"fcstGordonSimplifyGeneric-ID325",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,5].SpinorVD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[-Momentum[p2, D], m2, 1])/(m1 - m2) + \
+(2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], m2, 1])/(m1 - m2) - (Spinor[-Momentum[p1, \
+D], m1, 1] . GA[5] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, \
+mu])/(m1 - m2)"},
+{"fcstGordonSimplifyGeneric-ID326",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,5].SpinorVD[p2,m2],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m2, 1])/(m1 + m2) - \
+(2*Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], m2, 1])/(m1 + m2) + (Spinor[Momentum[p1, D], \
+m1, 1] . GA[5] . Spinor[-Momentum[p2, D], m2, 1]*FVD[p1 + p2, \
+mu])/(m1 + m2)"},
+{"fcstGordonSimplifyGeneric-ID327",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,5].SpinorUD[p2,m2],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m1, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[Momentum[p2, D], m2, 1])/(m1 + m2) + \
+(2*Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], m2, 1])/(m1 + m2) - (Spinor[-Momentum[p1, D], \
+m1, 1] . GA[5] . Spinor[Momentum[p2, D], m2, 1]*FVD[p1 + p2, mu])/(m1 \
++ m2)"},
+{"fcstGordonSimplifyGeneric-ID328",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID329",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID330",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"((I/2)*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m - \
+Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], m, 1]/m + (Spinor[Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID331",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I/2)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], \
+GSD[p1 - p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m + \
+Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], m, 1]/m - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/(2*m)"},
+{"fcstGordonSimplifyGeneric-ID332",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I)*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m + \
+(2*Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], m, 1])/m - (Spinor[Momentum[p1, D], 0, 1] . \
+GA[5] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID333",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"(I*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m - \
+(2*Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], m, 1])/m + (Spinor[-Momentum[p1, D], 0, 1] . \
+GA[5] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID334",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,m],FCE->True]",
+"(I*Spinor[Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], m, 1])/m - \
+(2*Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], m, 1])/m + (Spinor[Momentum[p1, D], 0, 1] . \
+GA[5] . Spinor[-Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID335",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,m],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], 0, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], m, 1])/m + \
+(2*Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], m, 1])/m - (Spinor[-Momentum[p1, D], 0, 1] . \
+GA[5] . Spinor[Momentum[p2, D], m, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID336",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[Momentum[p2, D], 0, 1])/m - \
+(2*Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID337",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[-Momentum[p2, D], 0, 1])/m + \
+(2*Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID338",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"(I*Spinor[Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 - \
+p2]] . GA[5] . Spinor[-Momentum[p2, D], 0, 1])/m - \
+(2*Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1])/m + (Spinor[Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[-Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID339",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"((-I)*Spinor[-Momentum[p1, D], m, 1] . DiracSigma[GAD[mu], GSD[p1 \
+- p2]] . GA[5] . Spinor[Momentum[p2, D], 0, 1])/m + \
+(2*Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GSE[p2] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1])/m - (Spinor[-Momentum[p1, D], m, 1] . \
+GA[5] . Spinor[Momentum[p2, D], 0, 1]*FVD[p1 + p2, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID340",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID341",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID342",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,5].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID343",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,5].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID344",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,5].SpinorUD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID345",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,5].SpinorVD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID346",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,5].SpinorVD[p,m],FCE->True]",
+"-(Spinor[Momentum[p, D], m, 1] . GAD[mu] . GSE[p] . GA[5] . \
+Spinor[-Momentum[p, D], m, 1]/m) + (Spinor[Momentum[p, D], m, 1] . \
+GA[5] . Spinor[-Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID347",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,5].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GSE[p] . GA[5] . \
+Spinor[Momentum[p, D], m, 1]/m - (Spinor[-Momentum[p, D], m, 1] . \
+GA[5] . Spinor[Momentum[p, D], m, 1]*FVD[p, mu])/m"},
+{"fcstGordonSimplifyGeneric-ID348",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,5].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID349",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,5].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID350",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,5].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID351",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,5].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[5] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID352",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID353",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID354",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID355",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID356",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID357",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID358",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID359",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID360",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID361",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID362",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID363",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID364",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID365",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID366",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,6].SpinorVD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID367",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,6].SpinorUD[p2,m2],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID368",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID369",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID370",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID371",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,m],Inverse\[Rule]{m2},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID372",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID373",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID374",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID375",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID376",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID377",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID378",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,6].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID379",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,6].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID380",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,6].SpinorUD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID381",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,6].SpinorVD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID382",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,6].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID383",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,6].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID384",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,6].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID385",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,6].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID386",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,6].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID387",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,6].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[6] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID388",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID389",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID390",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID391",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID392",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID393",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID394",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID395",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID396",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID397",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID398",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,m],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID399",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,m],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID400",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID401",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID402",
+"GordonSimplify[SpinorUBarD[p1,m]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID403",
+"GordonSimplify[SpinorVBarD[p1,m]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID404",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID405",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID406",
+"GordonSimplify[SpinorUBarD[p1,0]. \
+GAD[mu,7].SpinorVD[p2,0],FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID407",
+"GordonSimplify[SpinorVBarD[p1,0]. \
+GAD[mu,7].SpinorUD[p2,0],FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID408",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,7].SpinorUD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID409",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,7].SpinorVD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID410",
+"GordonSimplify[SpinorUBarD[p,m]. \
+GAD[mu,7].SpinorVD[p,m],FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID411",
+"GordonSimplify[SpinorVBarD[p,m]. \
+GAD[mu,7].SpinorUD[p,m],FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID412",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,7].SpinorUD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID413",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,7].SpinorVD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID414",
+"GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,7].SpinorVD[p,0],FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID415",
+"GordonSimplify[SpinorVBarD[p,0]. \
+GAD[mu,7].SpinorUD[p,0],FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID416",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID417",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID418",
+"GordonSimplify[SpinorUBarD[p1,m1]. \
+GAD[mu,7].SpinorVD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID419",
+"GordonSimplify[SpinorVBarD[p1,m1]. \
+GAD[mu,7].SpinorUD[p2,m2],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m1, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m2, 1]"},
+{"fcstGordonSimplifyGeneric-ID420",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID421",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID422",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID423",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID424",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID425",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID426",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorVD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID427",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorUD[p2,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID428",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID429",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID430",
+"GordonSimplify[SpinorUBarD[p1,m]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID431",
+"GordonSimplify[SpinorVBarD[p1,m]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID432",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID433",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID434",
+"GordonSimplify[SpinorUBarD[p1,0]. GAD[mu,7].SpinorVD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID435",
+"GordonSimplify[SpinorVBarD[p1,0]. GAD[mu,7].SpinorUD[p2,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p1, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p2, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID436",
+"GordonSimplify[SpinorUBarD[p,m]. GAD[mu,7].SpinorUD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID437",
+"GordonSimplify[SpinorVBarD[p,m]. GAD[mu,7].SpinorVD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID438",
+"GordonSimplify[SpinorUBarD[p,m]. GAD[mu,7].SpinorVD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID439",
+"GordonSimplify[SpinorVBarD[p,m]. GAD[mu,7].SpinorUD[p,m],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p, D], m, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], m, 1]"},
+{"fcstGordonSimplifyGeneric-ID440",
+"GordonSimplify[SpinorUBarD[p,0]. GAD[mu,7].SpinorUD[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID441",
+"GordonSimplify[SpinorVBarD[p,0]. GAD[mu,7].SpinorVD[p,0],Select\
+\[Rule]{{Spinor[__],DiracGamma[__],DiracGamma[5],Spinor[__]},{Spinor[_\
+_],DiracGamma[__],DiracGamma[7],Spinor[__]},{Spinor[__],DiracGamma[__]\
+,Spinor[__]}},FCE->True]",
+"Spinor[-Momentum[p, D], 0, 1] . GAD[mu] . GA[7] . \
+Spinor[-Momentum[p, D], 0, 1]"},
+{"fcstGordonSimplifyGeneric-ID442",
+"tmp=GordonSimplify[SpinorUBarD[p,0]. \
+GAD[mu,7].SpinorVD[p,0],Select\[Rule]{{Spinor[__],DiracGamma[__],\
+DiracGamma[5],Spinor[__]},{Spinor[__],DiracGamma[__],DiracGamma[7],\
+Spinor[__]},{Spinor[__],DiracGamma[__],Spinor[__]}}];
+FCSetDiracGammaScheme[\"BMHV\"]; tmp",
+"Spinor[Momentum[p, D], 0, 1] . DiracGamma[LorentzIndex[mu, D], D] \
+. DiracGamma[7] . Spinor[-Momentum[p, D], 0, 1]"}
+});

--- a/Tests/Feynman/ToStandardMatrixElement.test
+++ b/Tests/Feynman/ToStandardMatrixElement.test
@@ -416,5 +416,17 @@ StandardMatrixElement[SpinorUBar[p, m].GA[mu].SpinorV[q, M]],
 FCE -> True]","StandardMatrixElement[
 Spinor[Momentum[p], m, 1].GA[mu].GA[6].Spinor[-Momentum[q], M, 1]] +
 StandardMatrixElement[
-Spinor[Momentum[p], m, 1].GA[mu].GA[7].Spinor[-Momentum[q], M, 1]]"}
+Spinor[Momentum[p], m, 1].GA[mu].GA[7].Spinor[-Momentum[q], M, 1]]"},
+{"fcstToStandardMatrixElement-ID17", "ToStandardMatrixElement[
+x SpinorUBarD[p].GAD[mu].SpinorUD[p] + y SpinorUBarD[p].SpinorUD[p],
+SpinorChainEvaluate -> False, FCE -> True]","y StandardMatrixElement[
+Spinor[Momentum[p, D], 0, 1].GA[6].Spinor[Momentum[p, D], 0, 1]] +
+y StandardMatrixElement[
+Spinor[Momentum[p, D], 0, 1].GA[7].Spinor[Momentum[p, D], 0, 1]] +
+x StandardMatrixElement[
+Spinor[Momentum[p, D], 0, 1].GAD[mu].GA[6].Spinor[Momentum[p, D],
+	0, 1]] +
+x StandardMatrixElement[
+Spinor[Momentum[p, D], 0, 1].GAD[mu].GA[7].Spinor[Momentum[p, D],
+	0, 1]]"}
 });

--- a/Tests/LoopIntegrals/TID.test
+++ b/Tests/LoopIntegrals/TID.test
@@ -1034,5 +1034,11 @@ DiracTrace[GAD[mu].GSD[p].GAD[nu].GAD[rho].GA[5]]) FAD[q, -p + q]"},
 PaVeLimitTo4 -> True, ToPaVe -> True, FCE -> True]",
 "1/18 I \[Pi]^2 x (FV[q, mu] FV[q, nu] - MT[mu, nu] SP[q, q]) +
 1/12 I \[Pi]^2 x PaVe[0, {SP[q, q]}, {0, 0}] (4 FV[q, mu] FV[q, nu] -
-	MT[mu, nu] SP[q, q])"}
+	MT[mu, nu] SP[q, q])"},
+{"fcstTID-ID57","TID[(x SpinorUBarD[p].GAD[nu].SpinorUD[p] +
+	y SpinorUBarD[p].SpinorUD[p]) FVD[l, mu] FAD[l, l - p], l,
+SpinorChainEvaluate -> False, FCE -> True]",
+"1/2 (y Spinor[Momentum[p, D], 0, 1].Spinor[Momentum[p, D], 0, 1] +
+x Spinor[Momentum[p, D], 0, 1].GAD[nu].Spinor[Momentum[p, D], 0,
+	1]) FAD[l, l - p] FVD[p, mu]"}
 };


### PR DESCRIPTION
GordonSimplify is a routine for applying Gordon identities to suitable spinor chains of vector or axial-vector current type.

- [x] Documentation
- [x] Unit tests
- [x] Spinor types, masses and momenta can be different
- [x] Chiral identities work with NDR and BMHV g^5 schemes
- [x] Extra identities that can be derived by sandwiching a sigma between two spinors should be added to `DiracSimplify`

Some comments regarding the additional identities.

Stuff like
```
SpinorUBar[p, m].GA[5].SpinorU[p, m] == 0
SpinorVBar[p, m].GA[5].SpinorV[p, m] == 0
```
is straightforward to add, but in `D`-dims only when using NDR.

But for identities similar to 
`SpinorUBar[p, m].GA[mu].SpinorU[p, m] ==  FV[p, mu]/m SpinorUBar[p, m].SpinorU[p, m]`
we need a separate option: In some cases (e.g. when doing matching) one may not want to trade a vector current for a scalar current.