### PR TITLE
PaVeLimitTo4

### DIFF
--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/PaVeLimitTo4.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/PaVeLimitTo4.nb
@@ -1,0 +1,1089 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 10.4' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     30377,       1079]
+NotebookOptionsPosition[     25219,        892]
+NotebookOutlinePosition[     26032,        924]
+CellTagsIndexPosition[     25931,        918]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[TextData[{
+ "New in: ",
+ Cell["9.3", "HistoryData",
+  CellTags->"New"],
+ " | Modified in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Modified"],
+ " | Obsolete in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Obsolete"],
+ " | Excised in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Excised"]
+}], "History",
+ CellID->1247902091],
+
+Cell[CellGroupData[{
+
+Cell["Categorization", "CategorizationSection",
+ CellID->1122911449],
+
+Cell["Symbol", "Categorization",
+ CellLabel->"Entity Type",
+ CellID->686433507],
+
+Cell["FeynCalc", "Categorization",
+ CellLabel->"Paclet Name",
+ CellID->605800465],
+
+Cell["FeynCalc`", "Categorization",
+ CellLabel->"Context",
+ CellID->468444828],
+
+Cell["FeynCalc/ref/PaVeLimitTo4", "Categorization",
+ CellLabel->"URI"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Keywords", "KeywordsSection",
+ CellID->477174294],
+
+Cell["XXXX", "Keywords",
+ CellID->1164421360]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Syntax Templates", "TemplatesSection",
+ CellID->1872225408],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Additional Function Template",
+ CellID->1562036412],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Arguments Pattern",
+ CellID->158391909],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Local Variables",
+ CellID->1360575930],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Color Equal Signs",
+ CellID->793782254]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Details", "DetailsSection",
+ CellID->307771771],
+
+Cell["XXXX", "Details",
+ CellLabel->"Lead",
+ CellID->670882175],
+
+Cell["XXXX", "Details",
+ CellLabel->"Developers",
+ CellID->350963985],
+
+Cell["XXXX", "Details",
+ CellLabel->"Authors",
+ CellID->8391405],
+
+Cell["XXXX", "Details",
+ CellLabel->"Feature Name",
+ CellID->3610269],
+
+Cell["XXXX", "Details",
+ CellLabel->"QA",
+ CellID->401364205],
+
+Cell["XXXX", "Details",
+ CellLabel->"DA",
+ CellID->350204745],
+
+Cell["XXXX", "Details",
+ CellLabel->"Docs",
+ CellID->732958810],
+
+Cell["XXXX", "Details",
+ CellLabel->"Features Page Notes",
+ CellID->222905350],
+
+Cell["XXXX", "Details",
+ CellLabel->"Comments",
+ CellID->240026365]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["PaVeLimitTo4", "ObjectName",
+ CellID->1224892054],
+
+Cell[TextData[{
+ Cell["   ", "ModInfo"],
+ Cell[BoxData[
+  RowBox[{"PaVeLimitTo4", "[", "expr", "]"}]], "InlineFormula"],
+ "  simplifies products of Passarino-Veltman functions and D-dependent \
+prefactors by evaluating the prefactors at D=4 and adding an extra term from \
+the product of (D-4) and the UV pole of the Passarino-Veltman function. This \
+is possible because the UV poles of arbitrary Passarino-Veltman functions can \
+be determined via PaVeUVPart. The result is valid up to 0th order in Epsilon, \
+i.e. it is sufficient for 1-loop calculations."
+}], "Usage",
+ CellChangeTimes->{{3.808045792704583*^9, 3.808045830111466*^9}, 
+   3.808045860694276*^9},
+ CellID->982511436],
+
+Cell["\<\
+Warning! This simplification always ignores possible IR poles of \
+Passarino-Veltman functions. Therefore, it can be used only if all IR poles \
+are regulated without using dimensional regularization (e.g. by assigning \
+gluons or photons a fake mass) or if it is known in advance that the given \
+expression is free of IR singularities.
+\
+\>", "Notes",
+ CellChangeTimes->{{3.808045837887301*^9, 3.808045845719984*^9}},
+ CellID->1067943069],
+
+Cell["\<\
+The action of PaVeLimitTo4 is equivalent to using the old OneLoop routine \
+with the flags $LimitTo4 and $LimitTo4IRUnsafe set to True.\
+\>", "Notes",
+ CellChangeTimes->{{3.808045855063899*^9, 3.8080458553834677`*^9}},
+ CellID->1210171526],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Options", "[", "PaVeLimitTo4", "]"}]], "Input",
+ CellChangeTimes->{3.8080458943098383`*^9},
+ CellTags->"TID",
+ CellLabel->"In[9]:=",
+ CellID->1576573941],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"{", 
+   RowBox[{
+    RowBox[{"Collecting", "\[Rule]", "True"}], ",", 
+    RowBox[{"Dimension", "\[Rule]", "D"}], ",", 
+    RowBox[{"FeynCalcExternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FeynCalcInternal", "\[Rule]", "False"}], ",", 
+    RowBox[{"FCVerbose", "\[Rule]", "False"}], ",", 
+    RowBox[{"Factoring", "\[Rule]", 
+     RowBox[{"{", 
+      RowBox[{"Factor2", ",", "5000"}], "}"}]}], ",", 
+    RowBox[{"TimeConstrained", "\[Rule]", "3"}], ",", 
+    RowBox[{"Together", "\[Rule]", "True"}]}], "}"}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.808045904010024*^9},
+ CellTags->"TID",
+ CellLabel->"Out[9]=",
+ CellID->1570702841]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Tutorials", "TutorialsSection",
+ CellID->250839057],
+
+Cell["XXXX", "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Demonstrations", "RelatedDemonstrationsSection",
+ CellID->1268215905],
+
+Cell["XXXX", "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Links", "RelatedLinksSection",
+ CellID->1584193535],
+
+Cell["XXXX", "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["See Also", "SeeAlsoSection",
+ CellID->1255426704],
+
+Cell["XXXX", "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More About", "MoreAboutSection",
+ CellID->38303248],
+
+Cell["XXXX", "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[GridBox[{
+    {
+     StyleBox["Examples", "PrimaryExamplesSection"], 
+     ButtonBox[
+      RowBox[{
+       RowBox[{"More", " ", "Examples"}], " ", "\[RightTriangle]"}],
+      BaseStyle->"ExtendedExamplesLink",
+      ButtonData:>"ExtendedExamples"]}
+   }],
+  $Line = 0; Null]], "PrimaryExamplesSection",
+ CellID->880084151],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"D", "-", "2"}], ")"}], "/", 
+    RowBox[{"(", 
+     RowBox[{"D", "-", "3"}], ")"}]}], 
+   RowBox[{"A0", "[", 
+    RowBox[{"m", "^", "2"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.808045917006484*^9, 3.8080459337201853`*^9}},
+ CellLabel->"In[11]:=",
+ CellID->1649313210],
+
+Cell[BoxData[
+ FormBox[
+  FractionBox[
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"D", "-", "2"}], ")"}], " ", 
+    FormBox[
+     TagBox[
+      FormBox[
+       RowBox[{
+        SubscriptBox["\<\"A\"\>", "\<\"0\"\>"], "(", 
+        SuperscriptBox["m", "2"], ")"}],
+       TraditionalForm],
+      HoldForm],
+     TraditionalForm]}], 
+   RowBox[{"D", "-", "3"}]], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8080459273217583`*^9, 3.808045934103281*^9}},
+ CellLabel->"Out[11]=",
+ CellID->106445569]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"PaVeLimitTo4", "[", "ex", "]"}]], "Input",
+ CellChangeTimes->{{3.808045935673312*^9, 3.8080459488162613`*^9}},
+ CellLabel->"In[13]:=",
+ CellID->1754477081],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"2", " ", 
+    FormBox[
+     RowBox[{
+      SubscriptBox["\<\"A\"\>", "\<\"0\"\>"], "(", 
+      SuperscriptBox["m", "2"], ")"}],
+     TraditionalForm]}], "+", 
+   RowBox[{"2", " ", 
+    SuperscriptBox["m", "2"]}]}], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.8080459391622133`*^9, 3.8080459492458*^9}},
+ CellLabel->"Out[13]=",
+ CellID->2004029035]
+}, Open  ]],
+
+Cell["\<\
+Simplify the amplitude for the process of a Higgs decaying two to gluons at \
+1-loop\
+\>", "Notes",
+ CellChangeTimes->{{3.8080459925676517`*^9, 3.808046022863709*^9}},
+ CellID->538152640],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"ex", "=", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"-", 
+     FractionBox["1", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{
+         RowBox[{"-", "2"}], "+", "D"}], ")"}], " ", 
+       SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}]]}], "2", " ", 
+    "\[ImaginaryI]", " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"-", "4"}], "+", "D"}], ")"}], " ", "e", " ", 
+    SuperscriptBox["gs", "2"], " ", 
+    SuperscriptBox["mt", "2"], " ", 
+    SuperscriptBox["\[Pi]", "2"], " ", 
+    RowBox[{"B0", "[", 
+     RowBox[{
+      SuperscriptBox["mH", "2"], ",", 
+      SuperscriptBox["mt", "2"], ",", 
+      SuperscriptBox["mt", "2"]}], "]"}], " ", 
+    RowBox[{"SD", "[", 
+     RowBox[{"Glu2", ",", "Glu3"}], "]"}], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"-", "2"}], " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{"k1", ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k2", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], "]"}], 
+       " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{"k2", ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k1", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], "]"}]}], 
+      "+", 
+      RowBox[{
+       SuperscriptBox["mH", "2"], " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k1", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}], ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k2", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], 
+        "]"}]}]}], ")"}]}], "-", 
+   RowBox[{
+    FractionBox["1", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{
+        RowBox[{"-", "2"}], "+", "D"}], ")"}], " ", 
+      SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}]], "\[ImaginaryI]", 
+    " ", "e", " ", 
+    SuperscriptBox["gs", "2"], " ", 
+    SuperscriptBox["mt", "2"], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"-", "2"}], " ", 
+       SuperscriptBox["mH", "2"]}], "+", 
+      RowBox[{"D", " ", 
+       SuperscriptBox["mH", "2"]}], "-", 
+      RowBox[{"8", " ", 
+       SuperscriptBox["mt", "2"]}]}], ")"}], " ", 
+    SuperscriptBox["\[Pi]", "2"], " ", 
+    RowBox[{"C0", "[", 
+     RowBox[{"0", ",", "0", ",", 
+      SuperscriptBox["mH", "2"], ",", 
+      SuperscriptBox["mt", "2"], ",", 
+      SuperscriptBox["mt", "2"], ",", 
+      SuperscriptBox["mt", "2"]}], "]"}], " ", 
+    RowBox[{"SD", "[", 
+     RowBox[{"Glu2", ",", "Glu3"}], "]"}], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"-", "2"}], " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{"k1", ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k2", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], "]"}], 
+       " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{"k2", ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k1", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], "]"}]}], 
+      "+", 
+      RowBox[{
+       SuperscriptBox["mH", "2"], " ", 
+       RowBox[{"SPD", "[", 
+        RowBox[{
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k1", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}], ",", 
+         RowBox[{"Polarization", "[", 
+          RowBox[{"k2", ",", 
+           RowBox[{"-", "\[ImaginaryI]"}], ",", 
+           RowBox[{"Transversality", "\[Rule]", "True"}]}], "]"}]}], 
+        "]"}]}]}], ")"}]}]}]}]], "Input",
+ CellChangeTimes->{{3.808045961448003*^9, 3.808045971322177*^9}},
+ CellLabel->"In[16]:=",
+ CellID->971182643],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{"-", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{"2", " ", "\[ImaginaryI]", " ", 
+        SuperscriptBox["\[Pi]", "2"], " ", 
+        RowBox[{"(", 
+         RowBox[{"D", "-", "4"}], ")"}], " ", "e", " ", 
+        SuperscriptBox["gs", "2"], " ", 
+        SuperscriptBox["mt", "2"], " ", 
+        SuperscriptBox["\[Delta]", 
+         RowBox[{
+          FormBox["Glu2",
+           TraditionalForm], 
+          FormBox["Glu3",
+           TraditionalForm]}]], " ", 
+        FormBox[
+         TagBox[
+          FormBox[
+           RowBox[{
+            SubscriptBox["\<\"B\"\>", "\<\"0\"\>"], "(", 
+            RowBox[{
+             SuperscriptBox["mH", "2"], ",", 
+             SuperscriptBox["mt", "2"], ",", 
+             SuperscriptBox["mt", "2"]}], ")"}],
+           TraditionalForm],
+          HoldForm],
+         TraditionalForm], " ", 
+        RowBox[{"(", 
+         RowBox[{
+          RowBox[{
+           SuperscriptBox["mH", "2"], " ", 
+           RowBox[{"(", 
+            FormBox[
+             RowBox[{
+              FormBox[
+               RowBox[{
+                SuperscriptBox[
+                 FormBox["\<\"\[CurlyEpsilon]\"\>",
+                  TraditionalForm], "*"], "(", 
+                FormBox["k1",
+                 TraditionalForm], ")"}],
+               TraditionalForm], 
+              FormBox["\<\"\[CenterDot]\"\>",
+               TraditionalForm], 
+              FormBox[
+               RowBox[{
+                SuperscriptBox[
+                 FormBox["\<\"\[CurlyEpsilon]\"\>",
+                  TraditionalForm], "*"], "(", 
+                FormBox["k2",
+                 TraditionalForm], ")"}],
+               TraditionalForm]}],
+             TraditionalForm], ")"}]}], "-", 
+          RowBox[{"2", " ", 
+           RowBox[{"(", 
+            FormBox[
+             RowBox[{
+              FormBox[
+               FormBox["k1",
+                TraditionalForm],
+               TraditionalForm], 
+              FormBox["\<\"\[CenterDot]\"\>",
+               TraditionalForm], 
+              FormBox[
+               RowBox[{
+                SuperscriptBox[
+                 FormBox["\<\"\[CurlyEpsilon]\"\>",
+                  TraditionalForm], "*"], "(", 
+                FormBox["k2",
+                 TraditionalForm], ")"}],
+               TraditionalForm]}],
+             TraditionalForm], ")"}], " ", 
+           RowBox[{"(", 
+            FormBox[
+             RowBox[{
+              FormBox[
+               FormBox["k2",
+                TraditionalForm],
+               TraditionalForm], 
+              FormBox["\<\"\[CenterDot]\"\>",
+               TraditionalForm], 
+              FormBox[
+               RowBox[{
+                SuperscriptBox[
+                 FormBox["\<\"\[CurlyEpsilon]\"\>",
+                  TraditionalForm], "*"], "(", 
+                FormBox["k1",
+                 TraditionalForm], ")"}],
+               TraditionalForm]}],
+             TraditionalForm], ")"}]}]}], ")"}]}], ")"}], "/", 
+      RowBox[{"(", 
+       RowBox[{
+        RowBox[{"(", 
+         RowBox[{"D", "-", "2"}], ")"}], " ", 
+        SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}], ")"}]}], ")"}]}],
+    "-", 
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"\[ImaginaryI]", " ", 
+      SuperscriptBox["\[Pi]", "2"], " ", "e", " ", 
+      SuperscriptBox["gs", "2"], " ", 
+      SuperscriptBox["mt", "2"], " ", 
+      RowBox[{"(", 
+       RowBox[{
+        RowBox[{"D", " ", 
+         SuperscriptBox["mH", "2"]}], "-", 
+        RowBox[{"2", " ", 
+         SuperscriptBox["mH", "2"]}], "-", 
+        RowBox[{"8", " ", 
+         SuperscriptBox["mt", "2"]}]}], ")"}], " ", 
+      SuperscriptBox["\[Delta]", 
+       RowBox[{
+        FormBox["Glu2",
+         TraditionalForm], 
+        FormBox["Glu3",
+         TraditionalForm]}]], " ", 
+      FormBox[
+       TagBox[
+        FormBox[
+         RowBox[{
+          SubscriptBox["\<\"C\"\>", "\<\"0\"\>"], "(", 
+          RowBox[{"0", ",", "0", ",", 
+           SuperscriptBox["mH", "2"], ",", 
+           SuperscriptBox["mt", "2"], ",", 
+           SuperscriptBox["mt", "2"], ",", 
+           SuperscriptBox["mt", "2"]}], ")"}],
+         TraditionalForm],
+        HoldForm],
+       TraditionalForm], " ", 
+      RowBox[{"(", 
+       RowBox[{
+        RowBox[{
+         SuperscriptBox["mH", "2"], " ", 
+         RowBox[{"(", 
+          FormBox[
+           RowBox[{
+            FormBox[
+             RowBox[{
+              SuperscriptBox[
+               FormBox["\<\"\[CurlyEpsilon]\"\>",
+                TraditionalForm], "*"], "(", 
+              FormBox["k1",
+               TraditionalForm], ")"}],
+             TraditionalForm], 
+            FormBox["\<\"\[CenterDot]\"\>",
+             TraditionalForm], 
+            FormBox[
+             RowBox[{
+              SuperscriptBox[
+               FormBox["\<\"\[CurlyEpsilon]\"\>",
+                TraditionalForm], "*"], "(", 
+              FormBox["k2",
+               TraditionalForm], ")"}],
+             TraditionalForm]}],
+           TraditionalForm], ")"}]}], "-", 
+        RowBox[{"2", " ", 
+         RowBox[{"(", 
+          FormBox[
+           RowBox[{
+            FormBox[
+             FormBox["k1",
+              TraditionalForm],
+             TraditionalForm], 
+            FormBox["\<\"\[CenterDot]\"\>",
+             TraditionalForm], 
+            FormBox[
+             RowBox[{
+              SuperscriptBox[
+               FormBox["\<\"\[CurlyEpsilon]\"\>",
+                TraditionalForm], "*"], "(", 
+              FormBox["k2",
+               TraditionalForm], ")"}],
+             TraditionalForm]}],
+           TraditionalForm], ")"}], " ", 
+         RowBox[{"(", 
+          FormBox[
+           RowBox[{
+            FormBox[
+             FormBox["k2",
+              TraditionalForm],
+             TraditionalForm], 
+            FormBox["\<\"\[CenterDot]\"\>",
+             TraditionalForm], 
+            FormBox[
+             RowBox[{
+              SuperscriptBox[
+               FormBox["\<\"\[CurlyEpsilon]\"\>",
+                TraditionalForm], "*"], "(", 
+              FormBox["k1",
+               TraditionalForm], ")"}],
+             TraditionalForm]}],
+           TraditionalForm], ")"}]}]}], ")"}]}], ")"}], "/", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"(", 
+       RowBox[{"D", "-", "2"}], ")"}], " ", 
+      SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}], ")"}]}]}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.808045964106628*^9, 3.808046024268276*^9},
+ CellLabel->"Out[16]=",
+ CellID->85647389]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"PaVeLimitTo4", "[", "ex", "]"}]], "Input",
+ CellLabel->"In[17]:=",
+ CellID->1868795145],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    FractionBox["1", 
+     RowBox[{
+      SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}]], 
+    RowBox[{"\[ImaginaryI]", " ", 
+     SuperscriptBox["\[Pi]", "2"], " ", "e", " ", 
+     SuperscriptBox["gs", "2"], " ", 
+     SuperscriptBox["mt", "2"], " ", 
+     RowBox[{"(", 
+      RowBox[{
+       SuperscriptBox["mH", "2"], "-", 
+       RowBox[{"4", " ", 
+        SuperscriptBox["mt", "2"]}]}], ")"}], " ", 
+     SuperscriptBox["\[Delta]", 
+      RowBox[{
+       FormBox[
+        FormBox["Glu2",
+         TraditionalForm],
+        TraditionalForm], 
+       FormBox[
+        FormBox["Glu3",
+         TraditionalForm],
+        TraditionalForm]}]], " ", 
+     FormBox[
+      RowBox[{
+       SubscriptBox["\<\"C\"\>", "\<\"0\"\>"], "(", 
+       RowBox[{"0", ",", "0", ",", 
+        SuperscriptBox["mH", "2"], ",", 
+        SuperscriptBox["mt", "2"], ",", 
+        SuperscriptBox["mt", "2"], ",", 
+        SuperscriptBox["mt", "2"]}], ")"}],
+      TraditionalForm], " ", 
+     RowBox[{"(", 
+      RowBox[{
+       RowBox[{"2", " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           OverscriptBox[
+            FormBox["k1",
+             TraditionalForm], "_"],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k2",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}], " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           OverscriptBox[
+            FormBox["k2",
+             TraditionalForm], "_"],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k1",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}]}], "-", 
+       RowBox[{
+        SuperscriptBox["mH", "2"], " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k1",
+             TraditionalForm], ")"}],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k2",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}]}]}], ")"}]}]}], "-", 
+   RowBox[{
+    FractionBox["1", 
+     RowBox[{
+      SuperscriptBox["mH", "2"], " ", "mW", " ", "sinW"}]], 
+    RowBox[{"2", " ", "\[ImaginaryI]", " ", 
+     SuperscriptBox["\[Pi]", "2"], " ", "e", " ", 
+     SuperscriptBox["gs", "2"], " ", 
+     SuperscriptBox["mt", "2"], " ", 
+     SuperscriptBox["\[Delta]", 
+      RowBox[{
+       FormBox[
+        FormBox["Glu2",
+         TraditionalForm],
+        TraditionalForm], 
+       FormBox[
+        FormBox["Glu3",
+         TraditionalForm],
+        TraditionalForm]}]], " ", 
+     RowBox[{"(", 
+      RowBox[{
+       RowBox[{"2", " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           OverscriptBox[
+            FormBox["k1",
+             TraditionalForm], "_"],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k2",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}], " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           OverscriptBox[
+            FormBox["k2",
+             TraditionalForm], "_"],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k1",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}]}], "-", 
+       RowBox[{
+        SuperscriptBox["mH", "2"], " ", 
+        RowBox[{"(", 
+         RowBox[{
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k1",
+             TraditionalForm], ")"}],
+           TraditionalForm], 
+          FormBox["\<\"\[CenterDot]\"\>",
+           TraditionalForm], 
+          FormBox[
+           RowBox[{
+            SuperscriptBox[
+             OverscriptBox["\[CurlyEpsilon]", "_"], "*"], "(", 
+            FormBox["k2",
+             TraditionalForm], ")"}],
+           TraditionalForm]}], ")"}]}]}], ")"}]}]}]}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.8080459840873137`*^9, 3.8080460252941*^9},
+ CellLabel->"Out[17]=",
+ CellID->461102611]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More Examples", "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Scope", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1293636265],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Generalizations & Extensions", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1020263627],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["Options", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2061341341],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1757724783],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Applications", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->258228157],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Properties & Relations", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2123667759],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Possible Issues", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1305812373],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Interactive Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1653164318],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Neat Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+},
+WindowSize->{700, 770},
+WindowMargins->{{Automatic, 134}, {50, Automatic}},
+CellContext->"Global`",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
+StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
+  CharacterEncoding -> "UTF-8"]
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "TID"->{
+  Cell[4110, 170, 177, 5, 20, "Input",
+   CellTags->"TID",
+   CellID->1576573941],
+  Cell[4290, 177, 682, 18, 50, "Output",
+   CellTags->"TID",
+   CellID->1570702841]},
+ "ExtendedExamples"->{
+  Cell[23699, 834, 100, 2, 42, "ExtendedExamplesSection",
+   CellTags->"ExtendedExamples",
+   CellID->1854448968]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"TID", 25600, 904},
+ {"ExtendedExamples", 25792, 911}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 325, 14, 19, "History",
+ CellID->1247902091],
+Cell[CellGroupData[{
+Cell[908, 38, 68, 1, 22, "CategorizationSection",
+ CellID->1122911449],
+Cell[979, 41, 79, 2, 70, "Categorization",
+ CellID->686433507],
+Cell[1061, 45, 81, 2, 70, "Categorization",
+ CellID->605800465],
+Cell[1145, 49, 78, 2, 70, "Categorization",
+ CellID->468444828],
+Cell[1226, 53, 70, 1, 70, "Categorization"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1333, 59, 55, 1, 15, "KeywordsSection",
+ CellID->477174294],
+Cell[1391, 62, 45, 1, 70, "Keywords",
+ CellID->1164421360]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1473, 68, 65, 1, 15, "TemplatesSection",
+ CellID->1872225408],
+Cell[1541, 71, 94, 2, 70, "Template",
+ CellID->1562036412],
+Cell[1638, 75, 82, 2, 70, "Template",
+ CellID->158391909],
+Cell[1723, 79, 81, 2, 70, "Template",
+ CellID->1360575930],
+Cell[1807, 83, 82, 2, 70, "Template",
+ CellID->793782254]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1926, 90, 53, 1, 15, "DetailsSection",
+ CellID->307771771],
+Cell[1982, 93, 63, 2, 70, "Details",
+ CellID->670882175],
+Cell[2048, 97, 69, 2, 70, "Details",
+ CellID->350963985],
+Cell[2120, 101, 64, 2, 70, "Details",
+ CellID->8391405],
+Cell[2187, 105, 69, 2, 70, "Details",
+ CellID->3610269],
+Cell[2259, 109, 61, 2, 70, "Details",
+ CellID->401364205],
+Cell[2323, 113, 61, 2, 70, "Details",
+ CellID->350204745],
+Cell[2387, 117, 63, 2, 70, "Details",
+ CellID->732958810],
+Cell[2453, 121, 78, 2, 70, "Details",
+ CellID->222905350],
+Cell[2534, 125, 67, 2, 70, "Details",
+ CellID->240026365]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[2638, 132, 55, 1, 48, "ObjectName",
+ CellID->1224892054],
+Cell[2696, 135, 684, 13, 107, "Usage",
+ CellID->982511436],
+Cell[3383, 150, 450, 9, 70, "Notes",
+ CellID->1067943069],
+Cell[3836, 161, 249, 5, 32, "Notes",
+ CellID->1210171526],
+Cell[CellGroupData[{
+Cell[4110, 170, 177, 5, 20, "Input",
+ CellTags->"TID",
+ CellID->1576573941],
+Cell[4290, 177, 682, 18, 50, "Output",
+ CellTags->"TID",
+ CellID->1570702841]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5021, 201, 57, 1, 35, "TutorialsSection",
+ CellID->250839057],
+Cell[5081, 204, 45, 1, 15, "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5163, 210, 83, 1, 25, "RelatedDemonstrationsSection",
+ CellID->1268215905],
+Cell[5249, 213, 58, 1, 15, "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5344, 219, 65, 1, 25, "RelatedLinksSection",
+ CellID->1584193535],
+Cell[5412, 222, 49, 1, 15, "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5498, 228, 55, 1, 25, "SeeAlsoSection",
+ CellID->1255426704],
+Cell[5556, 231, 43, 1, 15, "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5636, 237, 57, 1, 25, "MoreAboutSection",
+ CellID->38303248],
+Cell[5696, 240, 46, 1, 15, "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[5779, 246, 356, 11, 53, "PrimaryExamplesSection",
+ CellID->880084151],
+Cell[CellGroupData[{
+Cell[6160, 261, 362, 12, 20, "Input",
+ CellID->1649313210],
+Cell[6525, 275, 501, 18, 41, "Output",
+ CellID->106445569]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[7063, 298, 179, 4, 20, "Input",
+ CellID->1754477081],
+Cell[7245, 304, 401, 13, 24, "Output",
+ CellID->2004029035]
+}, Open  ]],
+Cell[7661, 320, 197, 5, 19, "Notes",
+ CellID->538152640],
+Cell[CellGroupData[{
+Cell[7883, 329, 4022, 117, 249, "Input",
+ CellID->971182643],
+Cell[11908, 448, 6538, 204, 164, "Output",
+ CellID->85647389]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[18483, 657, 111, 3, 20, "Input",
+ CellID->1868795145],
+Cell[18597, 662, 5053, 166, 136, "Output",
+ CellID->461102611]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[23699, 834, 100, 2, 42, "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+Cell[23802, 838, 125, 3, 25, "ExampleSection",
+ CellID->1293636265],
+Cell[23930, 843, 148, 3, 17, "ExampleSection",
+ CellID->1020263627],
+Cell[CellGroupData[{
+Cell[24103, 850, 127, 3, 17, "ExampleSection",
+ CellID->2061341341],
+Cell[24233, 855, 130, 3, 70, "ExampleSubsection",
+ CellID->1757724783],
+Cell[24366, 860, 130, 3, 70, "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+Cell[24511, 866, 131, 3, 17, "ExampleSection",
+ CellID->258228157],
+Cell[24645, 871, 142, 3, 17, "ExampleSection",
+ CellID->2123667759],
+Cell[24790, 876, 135, 3, 17, "ExampleSection",
+ CellID->1305812373],
+Cell[24928, 881, 140, 3, 17, "ExampleSection",
+ CellID->1653164318],
+Cell[25071, 886, 132, 3, 17, "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+}
+]
+*)
+
+(* End of internal cache information *)
+

--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/TID.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/TID.nb
@@ -2439,6 +2439,292 @@ Cell[BoxData[
      ")"}]}]}], TraditionalForm]], "Output",
  CellLabel->"Out[88]=",
  CellID->2601191]
+}, Open  ]],
+
+Cell["\<\
+To simplify manifestly IR finite 1-loop results written in terms of \
+Passarino-Veltman functions, we may employ the option PaVeLimitTo4 (must be \
+used together with ToPaVe).\[LineSeparator]The result is valid up to 0th \
+order in Epsilon, i.e. sufficient for 1-loop calculations.\
+\>", "Notes",
+ CellID->1566396299],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"FCClearScalarProducts", "[", "]"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{"int", "=", 
+  RowBox[{
+   RowBox[{"(", 
+    RowBox[{"D", "-", "1"}], ")"}], 
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"D", "-", "2"}], ")"}], "/", 
+    RowBox[{"(", 
+     RowBox[{"D", "-", "3"}], ")"}]}], 
+   RowBox[{"FVD", "[", 
+    RowBox[{"p", ",", "mu"}], "]"}], 
+   RowBox[{"FVD", "[", 
+    RowBox[{"p", ",", "nu"}], "]"}], 
+   RowBox[{"FAD", "[", 
+    RowBox[{"p", ",", 
+     RowBox[{"p", "-", "q"}]}], "]"}]}]}]}], "Input",
+ CellLabel->"In[1]:="],
+
+Cell[BoxData[
+ FormBox[
+  FractionBox[
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"D", "-", "2"}], ")"}], " ", 
+    RowBox[{"(", 
+     RowBox[{"D", "-", "1"}], ")"}], " ", 
+    FormBox[
+     SuperscriptBox[
+      FormBox[
+       FormBox["p",
+        TraditionalForm],
+       TraditionalForm], 
+      FormBox[
+       FormBox["mu",
+        TraditionalForm],
+       TraditionalForm]],
+     TraditionalForm], " ", 
+    FormBox[
+     SuperscriptBox[
+      FormBox[
+       FormBox["p",
+        TraditionalForm],
+       TraditionalForm], 
+      FormBox[
+       FormBox["nu",
+        TraditionalForm],
+       TraditionalForm]],
+     TraditionalForm]}], 
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{"D", "-", "3"}], ")"}], " ", 
+    RowBox[{
+     InterpretationBox[
+      SuperscriptBox[
+       FormBox[
+        FormBox["p",
+         TraditionalForm],
+        TraditionalForm], "2"],
+      SequenceForm[
+       FeynCalc`Pair[
+        FeynCalc`Momentum[$CellContext`p, D], 
+        FeynCalc`Momentum[$CellContext`p, D]]],
+      Editable->False], ".", 
+     InterpretationBox[
+      SuperscriptBox[
+       RowBox[{
+        FormBox["\<\"(\"\>",
+         TraditionalForm], 
+        FormBox[
+         FormBox[
+          RowBox[{
+           FormBox["p",
+            TraditionalForm], "-", 
+           FormBox["q",
+            TraditionalForm]}],
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox["\<\")\"\>",
+         TraditionalForm]}], "2"],
+      SequenceForm[
+       FeynCalc`Pair[
+        FeynCalc`Momentum[$CellContext`p - $CellContext`q, D], 
+        FeynCalc`Momentum[$CellContext`p - $CellContext`q, D]]],
+      Editable->False]}]}]], TraditionalForm]], "Output",
+ CellLabel->"Out[2]="]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"TID", "[", 
+  RowBox[{"int", ",", "p", ",", 
+   RowBox[{"ToPaVe", "\[Rule]", "True"}]}], "]"}]], "Input",
+ CellLabel->"In[3]:="],
+
+Cell[BoxData[
+ FormBox[
+  FractionBox[
+   RowBox[{"\[ImaginaryI]", " ", 
+    SuperscriptBox["\[Pi]", "2"], " ", 
+    RowBox[{"(", 
+     RowBox[{"2", "-", "D"}], ")"}], " ", 
+    FormBox[
+     TagBox[
+      FormBox[
+       RowBox[{
+        SubscriptBox["\<\"B\"\>", "\<\"0\"\>"], "(", 
+        RowBox[{
+         SuperscriptBox[
+          FormBox[
+           FormBox["q",
+            TraditionalForm],
+           TraditionalForm], "2"], ",", "0", ",", "0"}], ")"}],
+       TraditionalForm],
+      HoldForm],
+     TraditionalForm], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"D", " ", 
+       SuperscriptBox[
+        FormBox[
+         FormBox["q",
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox[
+         FormBox["mu",
+          TraditionalForm],
+         TraditionalForm]], " ", 
+       SuperscriptBox[
+        FormBox[
+         FormBox["q",
+          TraditionalForm],
+         TraditionalForm], 
+        FormBox[
+         FormBox["nu",
+          TraditionalForm],
+         TraditionalForm]]}], "-", 
+      RowBox[{
+       SuperscriptBox[
+        FormBox[
+         FormBox["q",
+          TraditionalForm],
+         TraditionalForm], "2"], " ", 
+       SuperscriptBox["g", 
+        RowBox[{
+         FormBox[
+          FormBox["mu",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox["nu",
+           TraditionalForm],
+          TraditionalForm]}]]}]}], ")"}]}], 
+   RowBox[{"4", " ", 
+    RowBox[{"(", 
+     RowBox[{"3", "-", "D"}], ")"}]}]], TraditionalForm]], "Output",
+ CellLabel->"Out[3]="]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"TID", "[", 
+  RowBox[{"int", ",", "p", ",", 
+   RowBox[{"ToPaVe", "\[Rule]", "True"}], ",", 
+   RowBox[{"PaVeLimitTo4", "\[Rule]", "True"}]}], "]"}]], "Input",
+ CellLabel->"In[4]:="],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{
+   RowBox[{
+    FractionBox["1", "2"], " ", "\[ImaginaryI]", " ", 
+    SuperscriptBox["\[Pi]", "2"], " ", 
+    FormBox[
+     RowBox[{
+      SubscriptBox["\<\"B\"\>", "\<\"0\"\>"], "(", 
+      RowBox[{
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], "2"], ",", "0", ",", "0"}], ")"}],
+     TraditionalForm], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"4", " ", 
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox[
+         FormBox["mu",
+          TraditionalForm],
+         TraditionalForm]], " ", 
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox[
+         FormBox["nu",
+          TraditionalForm],
+         TraditionalForm]]}], "-", 
+      RowBox[{
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], "2"], " ", 
+       SuperscriptBox[
+        OverscriptBox["g", "_"], 
+        RowBox[{
+         FormBox[
+          FormBox["mu",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox["nu",
+           TraditionalForm],
+          TraditionalForm]}]]}]}], ")"}]}], "+", 
+   RowBox[{
+    FractionBox["1", "2"], " ", "\[ImaginaryI]", " ", 
+    SuperscriptBox["\[Pi]", "2"], " ", 
+    RowBox[{"(", 
+     RowBox[{
+      RowBox[{"2", " ", 
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox[
+         FormBox["mu",
+          TraditionalForm],
+         TraditionalForm]], " ", 
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], 
+        FormBox[
+         FormBox["nu",
+          TraditionalForm],
+         TraditionalForm]]}], "-", 
+      RowBox[{
+       SuperscriptBox[
+        FormBox[
+         OverscriptBox[
+          FormBox["q",
+           TraditionalForm], "_"],
+         TraditionalForm], "2"], " ", 
+       SuperscriptBox[
+        OverscriptBox["g", "_"], 
+        RowBox[{
+         FormBox[
+          FormBox["mu",
+           TraditionalForm],
+          TraditionalForm], 
+         FormBox[
+          FormBox["nu",
+           TraditionalForm],
+          TraditionalForm]}]]}]}], ")"}]}]}], TraditionalForm]], "Output",
+ CellLabel->"Out[4]="]
 }, Open  ]]
 }, Open  ]],
 
@@ -2502,14 +2788,14 @@ Cell[BoxData[
  CellID->589267740]
 }, Open  ]]
 },
-WindowSize->{700, 684},
-WindowMargins->{{683, Automatic}, {Automatic, 118}},
+WindowSize->{700, 683},
+WindowMargins->{{Automatic, 671}, {Automatic, 123}},
 Visible->True,
 PrivateNotebookOptions->{"FileOutlineCache"->False},
 CreateCellID->False,
 CellContext->"Global`",
 TrackCellChangeTimes->False,
-FrontEndVersion->"10.3 for Linux x86 (64-bit) (December 10, 2015)",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
   CharacterEncoding -> "UTF-8"]
 ]

--- a/FeynCalc/FCMain.m
+++ b/FeynCalc/FCMain.m
@@ -160,7 +160,7 @@ $LeviCivitaSign=I which would give eps^{0123} = -I.";
 $LimitTo4::usage =
 "$LimitTo4 is a global variable that determines whether \
 UV-divergent Passarino-Veltman functions are simplified by \
-taking the limit D-4 -> 0. A general UV-finite \
+taking the limit D-4 -> 0. A general IR-finite \
 Passarino-Veltman function can be written as \
 PaVe = a/(D-4) + b + O(Epsilon), with a being the prefactor \
 of the pole and b being the finite part. Therefore, products \

--- a/FeynCalc/LoopIntegrals/FCLoopExtract.m
+++ b/FeynCalc/LoopIntegrals/FCLoopExtract.m
@@ -48,6 +48,7 @@ Options[FCLoopExtract] = {
 	MultiLoop 					-> False,
 	Numerator 					-> True,
 	PaVe 						-> True,
+	PaVeIntegralHeads 			-> FeynCalc`Package`PaVeHeadsList,
 	SFAD 						-> True,
 	TimeConstrained				-> 3
 };
@@ -76,22 +77,25 @@ FCLoopExtract[ex_, lmoms_, loopHead_, OptionsPattern[]] :=
 		];
 
 		rest  = Plus@@tmp[[irrel]];
-		loopInts = FCLoopIsolate[Plus@@tmp[[rel]], lmoms, FCI->True, Head->loopHead,
-									FAD  -> OptionValue[FAD],
-									CFAD -> OptionValue[CFAD],
-									SFAD -> OptionValue[SFAD],
-									Collecting -> OptionValue[Collecting],
-									DropScaleless-> OptionValue[DropScaleless],
-									MultiLoop-> OptionValue[MultiLoop],
-									PaVe-> OptionValue[PaVe],
-									Numerator-> OptionValue[Numerator],
-									ExpandScalarProduct -> OptionValue[ExpandScalarProduct],
-									Full -> OptionValue[Full],
-									Factoring->OptionValue[Factoring],
-									FCLoopIBPReducableQ->OptionValue[FCLoopIBPReducableQ],
-									GFAD -> OptionValue[GFAD],
-									Factoring -> OptionValue[Factoring],
-									TimeConstrained -> OptionValue[TimeConstrained]
+		loopInts = FCLoopIsolate[Plus@@tmp[[rel]], lmoms,
+									CFAD 				-> OptionValue[CFAD],
+									Collecting			-> OptionValue[Collecting],
+									DropScaleless		-> OptionValue[DropScaleless],
+									ExpandScalarProduct	-> OptionValue[ExpandScalarProduct],
+									FAD					-> OptionValue[FAD],
+									FCI					-> True,
+									FCLoopIBPReducableQ	-> OptionValue[FCLoopIBPReducableQ],
+									Factoring			-> OptionValue[Factoring],
+									Factoring			-> OptionValue[Factoring],
+									Full				-> OptionValue[Full],
+									GFAD				-> OptionValue[GFAD],
+									Head				-> loopHead,
+									MultiLoop			-> OptionValue[MultiLoop],
+									Numerator			-> OptionValue[Numerator],
+									PaVe				-> OptionValue[PaVe],
+									PaVeIntegralHeads	-> OptionValue[PaVeIntegralHeads],
+									SFAD				-> OptionValue[SFAD],
+									TimeConstrained		-> OptionValue[TimeConstrained]
 		];
 
 		If[ OptionValue[FCLoopBasisSplit],

--- a/FeynCalc/LoopIntegrals/PaVeLimitTo4.m
+++ b/FeynCalc/LoopIntegrals/PaVeLimitTo4.m
@@ -1,0 +1,168 @@
+(* ::Package:: *)
+
+
+
+(* :Title: PaVeLimitTo4                                                       *)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:	Extracts UV divergent parts of Passarino-Veltman
+				coefficient functions 										*)
+
+(* ------------------------------------------------------------------------ *)
+
+
+PaVeLimitTo4::usage =
+"PaVeLimitTo4[expr] simplifies products of Passarino-Veltman \
+functions and D-dependent prefactors by evaluating the prefactors \
+at D=4 and adding an extra term from the product of (D-4) and the \
+UV pole of the Passarino-Veltman function. This is possible because \
+the UV poles of arbitrary Passarino-Veltman functions can be determined \
+via PaVeUVPart. The result is valid up to 0th order in Epsilon, i.e. it \
+is sufficient for 1-loop calculations. \n
+Warning! This simplification always ignores possible IR poles of \
+Passarino-Veltman functions. Therefore, it can be used only if all IR poles \
+are regulated without using dimensional regularization (e.g. by assigning \
+gluons or photons a fake mass) or if it is known in advance that the given \
+expression is free of IR singularities.\n
+The action of PaVeLimitTo4 is equivalent to using the old OneLoop routine with \
+the flags $LimitTo4 and $LimitTo4IRUnsafe set to True.";
+
+PaVeLimitTo4::failmsg =
+"Error! PaVeLimitTo4 has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+(* ------------------------------------------------------------------------ *)
+
+Begin["`Package`"]
+End[]
+
+Begin["`PaVeLimitTo4`Private`"]
+
+dimVar::usage="";
+deriv::usage="";
+polePref::usage="";
+
+Options[PaVeLimitTo4] = {
+	Collecting		-> True,
+	Dimension 		-> D,
+	FCE 			-> False,
+	FCI				-> False,
+	FCVerbose 		-> False,
+	Factoring		-> {Factor2, 5000},
+	TimeConstrained -> 3,
+	Together 		-> True
+};
+
+PaVeLimitTo4[expr_,  OptionsPattern[]] :=
+	Block[{	ex,repList,res, dummy, rest, pvl4Verbose,
+			dim, time, loopInts,intsUnique,
+			intsUniqueEval, paVeInt, repRule},
+
+		dim	= OptionValue[Dimension];
+
+		If [OptionValue[FCVerbose]===False,
+			pvl4Verbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				pvl4Verbose=OptionValue[FCVerbose]
+			];
+		];
+
+		FCPrint[1, "PaVeLimitTo4: Entering.",  FCDoControl->pvl4Verbose];
+		FCPrint[3, "PaVeLimitTo4: Entering with: ",  expr, FCDoControl->pvl4Verbose];
+
+		If[ FreeQ2[expr,FeynCalc`Package`PaVeHeadsList],
+			Return[expr]
+		];
+
+		If[	OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		FCPrint[1, "PaVeLimitTo4: Applying FCLoopExtract.", FCDoControl->pvl4Verbose];
+		{rest,loopInts,intsUnique} = FCLoopExtract[ex,{dummy},paVeInt,PaVe->True, PaVeIntegralHeads->Join[FeynCalc`Package`PaVeHeadsList, {dim}], FCI->True];
+		FCPrint[3, "PaVeLimitTo4: List of the unique integrals: ",  intsUnique, FCDoControl->pvl4Verbose];
+
+		intsUniqueEval = ToPaVe2/@((intsUnique/.paVeInt->Identity));
+		FCPrint[3, "PaVeLimitTo4: List of the unique integrals after ToPaVe2: ",  intsUniqueEval, FCDoControl->pvl4Verbose];
+
+		intsUniqueEval = FCProductSplit[#, {PaVe}] & /@ intsUniqueEval;
+		FCPrint[3, "PaVeLimitTo4: List of the unique integrals after FCProductSplit: ",  intsUniqueEval, FCDoControl->pvl4Verbose];
+
+		If[	!MatchQ[intsUniqueEval, {{_, _PaVe} ..}],
+			Message[PaVeLimitTo4::failmsg,"The extracted loop integral is not a proper PaVe function."];
+			Abort[]
+		];
+
+		(*
+			If the prefactor or the PaVe-function depend on scalar products or similar quantitites,
+			they must be converted to 4 dimensions.
+		*)
+
+		intsUniqueEval = Map[ChangeDimension[#, 4, FCI -> True] &, intsUniqueEval] /. dim-> dimVar;
+		FCPrint[3, "PaVeLimitTo4: List of the unique integrals after ChangeDimension: ",  intsUniqueEval, FCDoControl->pvl4Verbose];
+
+		If[	!MatchQ[Internal`RationalFunctionQ[#[[1]], dimVar] & /@ intsUniqueEval, {True ..}],
+			Message[PaVeLimitTo4::failmsg,"The D-dependent prefactor must be a rational function of D."];
+			Abort[]
+		];
+
+		If[	!MatchQ[FreeQ[#[[2]], dimVar] & /@ intsUniqueEval, {True ..}],
+			Message[PaVeLimitTo4::failmsg,"The arguments of PaVe-functions may not depend on D."];
+			Abort[]
+		];
+
+		If[	!Quiet[Internal`ExceptionFreeQ[intsUniqueEval /. dimVar -> 4]],
+			Message[PaVeLimitTo4::failmsg, "Cannot handle PaVe functions multiplied by 1/Epsilon poles."];
+			Abort[]
+		];
+
+		time=AbsoluteTime[];
+		FCPrint[1, "PaVeLimitTo4: Taking the limit D->4", FCDoControl->pvl4Verbose];
+		intsUniqueEval = limitTo4Fun /@ intsUniqueEval;
+		FCPrint[1, "PaVeLimitTo4: Limit D->4 done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->pvl4Verbose];
+		FCPrint[3, "PaVeLimitTo4: Preliminary results for the unique integrals: ",  intsUniqueEval, FCDoControl->pvl4Verbose];
+
+		If[	!FreeQ2[intsUniqueEval,{limitTo4Fun, dimVar}],
+			Message[PaVeLimitTo4::failmsg, "Something went wrong when taking the limit D->4."];
+			Abort[]
+		];
+
+		repRule = Thread[Rule[intsUnique,intsUniqueEval]];
+		FCPrint[3, "PaVeLimitTo4: Replacement rule ",  repRule, FCDoControl->pvl4Verbose];
+
+		res = rest + loopInts /. Dispatch[repRule];
+
+		If[	OptionValue[Collecting],
+			time=AbsoluteTime[];
+			FCPrint[1, "PaVeLimitTo4: Applying Collect2.", FCDoControl->pvl4Verbose];
+			res = Collect2[res, FeynCalc`Package`PaVeHeadsList, Factoring->OptionValue[Factoring], TimeConstrained->OptionValue[TimeConstrained] ];
+			FCPrint[1, "PaVeLimitTo4: Collect2 done, timing: ", N[AbsoluteTime[] - time, 4], FCDoControl->pvl4Verbose];
+			FCPrint[3, "PaVeLimitTo4: After Collect2: ", res, FCDoControl->pvl4Verbose]
+		];
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[3, "PaVeLimitTo4: Leaving.", FCDoControl->pvl4Verbose];
+		FCPrint[3, "PaVeLimitTo4: Leaving with: ", res, FCDoControl->pvl4Verbose];
+
+		res
+
+	];
+
+
+limitTo4Fun[{pref_, int_PaVe}] :=
+	(pref /. dimVar -> 4) * int +
+	((D[pref, dimVar] /. dimVar -> 4) *((dimVar - 4) PaVeUVPart[int,Dimension -> dimVar,
+		FCI -> True, FCLoopExtract -> False]));
+
+FCPrint[1,"PaVeLimitTo4.m loaded."];
+End[]

--- a/FeynCalc/Lorentz/FCSchoutenBruteForce.m
+++ b/FeynCalc/Lorentz/FCSchoutenBruteForce.m
@@ -44,7 +44,7 @@ Options[FCSchoutenBruteForce] = {
 	Schouten 					-> False,
 	SchoutenAllowNegativeGain	-> False,
 	SchoutenAllowZeroGain		-> False,
-	Take -> 1
+	Take 						-> 1
 };
 
 checkSchouten[x_, repRule_]:=
@@ -76,7 +76,7 @@ FCSchoutenBruteForce[expr_, epsvars_List, vars_List/;(!OptionQ[vars] || vars==={
 
 
 		FCPrint[1, "FCSchoutenBruteForce: Entering.", FCDoControl->fcsbVerbose];
-		FCPrint[3, "FCSchoutenBruteForce: Entering with ", ex, FCDoControl->fcsbVerbose];
+		FCPrint[3, "FCSchoutenBruteForce: Entering with ", expr, FCDoControl->fcsbVerbose];
 
 		If[	OptionValue[FCI],
 			ex = expr,

--- a/Tests/LoopIntegrals/PaVeLimitTo4.test
+++ b/Tests/LoopIntegrals/PaVeLimitTo4.test
@@ -1,0 +1,52 @@
+
+
+(* :Title: PaVeLimitTo4.test                                          	    	*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for PaVeLimitTo4			  		*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`LoopIntegrals`PaVeLimitTo4 =
+({
+{"fcstPaVeLimitTo4-ID1", "PaVeLimitTo4[FAD[p,p-q],FCE\[Rule]True]",
+"FAD[p, p - q]"},
+{"fcstPaVeLimitTo4-ID2",
+"PaVeLimitTo4[SPD[p,q](D-2)(D-1)/(D-2)B0[pp,mm1,mm2]+x,FCE\[Rule]\
+True]", "x - 2*SP[p, q] + 3*PaVe[0, {pp}, {mm1, mm2}]*SP[p, q]"},
+{"fcstPaVeLimitTo4-ID3",
+"PaVeLimitTo4[((4*I)*Pi^2*B0[0, m^2, m^2]*MTD[mu, nu])/D + \
+((4*I)*m^2*Pi^2*C0[0, 0, 0, m^2, m^2, \
+m^2]*MTD[mu,nu])/D,FCE\[Rule]True]",
+"(I/2)*Pi^2*MT[mu, nu] + I*Pi^2*MT[mu, nu]*PaVe[0, {0}, {m^2, \
+m^2}] + I*m^2*Pi^2*MT[mu, nu]*PaVe[0, {0, 0, 0}, {m^2, m^2, m^2}]"},
+{"fcstPaVeLimitTo4-ID4",
+"PaVeLimitTo4[((-2*I)*(-4 + D)*e*gs^2*mt^2*Pi^2*B0[mH^2, mt^2, \
+mt^2]*SD[Glu2, Glu3]*(-2*SPD[k1, Polarization[k2, -I, Transversality -> \
+True]]*SPD[k2, Polarization[k1, -I, Transversality -> True]] + \
+mH^2*SPD[Polarization[k1, -I, Transversality -> True], \
+Polarization[k2, -I, Transversality -> True]]))/((-2 + \
+D)*mH^2*mW*sinW) - (I*e*gs^2*mt^2*(-2*mH^2 + D*mH^2 - \
+8*mt^2)*Pi^2*C0[0, 0, mH^2, mt^2, mt^2, mt^2]*SD[Glu2, Glu3]*     \
+(-2*SPD[k1, Polarization[k2, -I, Transversality -> True]]*SPD[k2, \
+Polarization[k1, -I, Transversality ->True]] + \
+mH^2*SPD[Polarization[k1, -I,Transversality -> True], \
+Polarization[k2, -I, Transversality -> True]]))/((-2 + \
+D)*mH^2*mW*sinW),FCE\[Rule]True]",
+"((-2*I)*e*gs^2*mt^2*Pi^2*SD[Glu2, Glu3]*(2*SP[k1, \
+Polarization[k2, -I, Transversality -> True]]*SP[k2, Polarization[k1, \
+-I, Transversality -> True]] - mH^2*SP[Polarization[k1, -I, \
+Transversality -> True], Polarization[k2, -I, Transversality -> \
+True]]))/(mH^2*mW*sinW) + (I*e*gs^2*mt^2*(mH^2 - 4*mt^2)*Pi^2*PaVe[0, \
+{0, 0, mH^2}, {mt^2, mt^2, mt^2}]*SD[Glu2, Glu3]*(2*SP[k1, \
+Polarization[k2, -I, Transversality -> True]]*SP[k2, Polarization[k1, \
+-I, Transversality -> True]] - mH^2*SP[Polarization[k1, -I, \
+Transversality -> True], Polarization[k2, -I, Transversality -> \
+True]]))/(mH^2*mW*sinW)"}
+})

--- a/Tests/LoopIntegrals/TID.test
+++ b/Tests/LoopIntegrals/TID.test
@@ -1029,5 +1029,10 @@ DiracSimplify -> False, FCE -> True]",
 "1/2 (2 m DiracTrace[GAD[mu].GAD[nu].GAD[rho].GA[5]] +
 DiracTrace[GAD[mu].GSD[p].GAD[nu].GAD[rho].GA[5]]) FAD[q, -p + q]"},
 {"fcstTID-ID55","TID[A0[m1] FVD[q, mu] FAD[q, q - p], q, FCE -> True]",
-"1/2 A0[m1] FAD[q, -p + q] FVD[p, mu]"}
+"1/2 A0[m1] FAD[q, -p + q] FVD[p, mu]"},
+{"fcstTID-ID56","TID[FVD[p, mu] FVD[p, nu] FAD[p, p - q], p, Prefactor -> x,
+PaVeLimitTo4 -> True, ToPaVe -> True, FCE -> True]",
+"1/18 I \[Pi]^2 x (FV[q, mu] FV[q, nu] - MT[mu, nu] SP[q, q]) +
+1/12 I \[Pi]^2 x PaVe[0, {SP[q, q]}, {0, 0}] (4 FV[q, mu] FV[q, nu] -
+	MT[mu, nu] SP[q, q])"}
 };

--- a/Tests/Shared/SharedTools.test
+++ b/Tests/Shared/SharedTools.test
@@ -160,7 +160,9 @@ Tests`Shared`fcstSharedToolsFCProductSplit =
 {"fcstSharedToolsFCProductSplit-ID9", "FCProductSplit[1, {x, y, z}]",
 "{1, 1}"},
 {"fcstSharedToolsFCProductSplit-ID10", "FCProductSplit[a b c, {}]",
-"{a b c, 1}"}
+"{a b c, 1}"},
+{"fcstSharedToolsFCProductSplit-ID11", "FCProductSplit[(D - 2)/(D - 3) B0[mH^2, mt^2, mt^2], {B0}]",
+"{(-2 + D)/(-3 + D), B0[mH^2, mt^2, mt^2]}"}
 });
 
 Tests`Shared`fcstSharedToolsFCSplit = {


### PR DESCRIPTION
This add a new routine `PaVeLimitTo4` which simplifies products of Passarino-Veltman functions and 
D-dependent prefactors by evaluating the prefactors at D=4 and adding an extra 
term from the product of (D-4) and the UV pole of the Passarino-Veltman function.

`TID` is able to apply this function to the output when the options `PaVeLimitTo4` and `ToPaVe` are both
set to `True`.