### PR TITLE
Improved Tdec's basis symmetrizer to employ Pak's algorithm.

### DIFF
--- a/Tests/LoopIntegrals/CTdec.test
+++ b/Tests/LoopIntegrals/CTdec.test
@@ -101,34 +101,27 @@ CartesianMomentum[p1]]^2)"},
 {"fcstCTdec-ID11",
 "CTdec[{{q1,$3050},{q1,$3489},{q2,$3047},{q2,$3488}},{k1},\
 Dimension\[Rule]D-1,List\[Rule]True,UseTIDL\[Rule]False,FCE\[Rule]\
-True]", "{{X1 -> -1 + D, X2 -> CSPD[q1, q1], X3 -> CSPD[q1, q2], X4 -> \
-CSPD[k1, q1], X5 -> CSPD[q2, q2], X6 -> CSPD[k1, q2], X7 -> CSPD[k1, \
-k1]}, -(((8*X4^2*X6^2 + 6*X1*X4^2*X6^2 + X1^2*X4^2*X6^2 - \
-2*X4^2*X5*X7 - X1*X4^2*X5*X7 - 8*X3*X4*X6*X7 - 4*X1*X3*X4*X6*X7 - \
-2*X2*X6^2*X7 - X1*X2*X6^2*X7 + 2*X3^2*X7^2 + X2*X5*X7^2)*CVD[k1, \
-$3047]*CVD[k1, $3050]*CVD[k1, $3488]*CVD[k1, $3489])/((1 - \
-X1^2)*X7^4)) + ((4*X4^2*X6^2 - X1^2*X4^2*X6^2 - 2*X4^2*X5*X7 + \
-X1^2*X4^2*X5*X7 - 4*X3*X4*X6*X7 + X1*X2*X6^2*X7 + 2*X3^2*X7^2 - \
-X1*X2*X5*X7^2)*CVD[k1, $3050]*CVD[k1, $3489]*KDD[$3047, $3488])/((2 - \
-X1)*(1 - X1^2)*X7^3) + ((4*X4^2*X6^2 - X1^2*X4^2*X6^2 - X4^2*X5*X7 - \
-4*X3*X4*X6*X7 + X1*X3*X4*X6*X7 + X1^2*X3*X4*X6*X7 - X2*X6^2*X7 + \
-X3^2*X7^2 - X1*X3^2*X7^2 + X2*X5*X7^2)*(CVD[k1, $3488]*CVD[k1, \
-$3489]*KDD[$3047, $3050] + CVD[k1, $3050]*CVD[k1, $3488]*KDD[$3047, \
-$3489]))/((2 - X1)*(1 - X1^2)*X7^3) + ((4*X4^2*X6^2 - X1^2*X4^2*X6^2 \
-+ X1*X4^2*X5*X7 - 4*X3*X4*X6*X7 - 2*X2*X6^2*X7 + X1^2*X2*X6^2*X7 + \
-2*X3^2*X7^2 - X1*X2*X5*X7^2)*CVD[k1, $3047]*CVD[k1, $3488]*KDD[$3050, \
-$3489])/((2 - X1)*(1 - X1^2)*X7^3) - ((2*X4^2*X6^2 - X1*X4^2*X6^2 + \
-X1*X4^2*X5*X7 - 4*X3*X4*X6*X7 + X1*X2*X6^2*X7 + 2*X3^2*X7^2 - \
-X1*X2*X5*X7^2)*KDD[$3047, $3488]*KDD[$3050, $3489])/((2 - X1)*(1 - \
-X1^2)*X7^2) + ((4*X4^2*X6^2 - X1^2*X4^2*X6^2 - X4^2*X5*X7 - \
-4*X3*X4*X6*X7 + X1*X3*X4*X6*X7 + X1^2*X3*X4*X6*X7 - X2*X6^2*X7 + \
-X3^2*X7^2 - X1*X3^2*X7^2 + X2*X5*X7^2)*(CVD[k1, $3047]*CVD[k1, \
-$3489]*KDD[$3050, $3488] + CVD[k1, $3047]*CVD[k1, $3050]*KDD[$3488, \
-$3489]))/((2 - X1)*(1 - X1^2)*X7^3) - ((2*X4^2*X6^2 - X1*X4^2*X6^2 - \
-X4^2*X5*X7 - 2*X3*X4*X6*X7 + 2*X1*X3*X4*X6*X7 - X2*X6^2*X7 + \
-X3^2*X7^2 - X1*X3^2*X7^2 + X2*X5*X7^2)*(KDD[$3047, $3489]*KDD[$3050, \
-$3488] + KDD[$3047, $3050]*KDD[$3488, $3489]))/((2 - X1)*(1 - \
-X1^2)*X7^2)}"},
+True]", "{{X1 -> -1 + D, X2 -> CSPD[q1, q1], X3 -> CSPD[q1, q2], X4 -> CSPD[k1, q1],
+X5 -> CSPD[q2, q2], X6 -> CSPD[k1, q2], X7 -> CSPD[k1, k1]}, -(((8*X4^2*X6^2 +
+6*X1*X4^2*X6^2 + X1^2*X4^2*X6^2 - 2*X4^2*X5*X7 - X1*X4^2*X5*X7 - 8*X3*X4*X6*X7 -
+4*X1*X3*X4*X6*X7 - 2*X2*X6^2*X7 - X1*X2*X6^2*X7 + 2*X3^2*X7^2 + X2*X5*X7^2)*CVD[k1,
+$3047]*CVD[k1, $3050]*CVD[k1, $3488]*CVD[k1, $3489])/((1 - X1^2)*X7^4)) +
+((4*X4^2*X6^2 - X1^2*X4^2*X6^2 - 2*X4^2*X5*X7 + X1^2*X4^2*X5*X7 -
+4*X3*X4*X6*X7 + X1*X2*X6^2*X7 + 2*X3^2*X7^2 - X1*X2*X5*X7^2)*CVD[k1,
+$3050]*CVD[k1, $3489]*KDD[$3047, $3488])/((2 - X1)*(1 - X1^2)*X7^3) +
+((4*X4^2*X6^2 - X1^2*X4^2*X6^2 + X1*X4^2*X5*X7 - 4*X3*X4*X6*X7 - 2*X2*X6^2*X7 +
+X1^2*X2*X6^2*X7 + 2*X3^2*X7^2 - X1*X2*X5*X7^2)*CVD[k1, $3047]*CVD[k1,
+$3488]*KDD[$3050, $3489])/((2 - X1)*(1 - X1^2)*X7^3) - ((2*X4^2*X6^2 -
+X1*X4^2*X6^2 + X1*X4^2*X5*X7 - 4*X3*X4*X6*X7 + X1*X2*X6^2*X7 + 2*X3^2*X7^2 -
+X1*X2*X5*X7^2)*KDD[$3047, $3488]*KDD[$3050, $3489])/((2 - X1)*(1 - X1^2)*X7^2) +
+((4*X4^2*X6^2 - X1^2*X4^2*X6^2 - X4^2*X5*X7 - 4*X3*X4*X6*X7 + X1*X3*X4*X6*X7 +
+X1^2*X3*X4*X6*X7 - X2*X6^2*X7 + X3^2*X7^2 - X1*X3^2*X7^2 + X2*X5*X7^2)*(CVD[k1,
+$3488]*CVD[k1, $3489]*KDD[$3047, $3050] + CVD[k1, $3050]*CVD[k1, $3488]*KDD[$3047,
+$3489] + CVD[k1, $3047]*CVD[k1, $3489]*KDD[$3050, $3488] + CVD[k1, $3047]*CVD[k1,
+$3050]*KDD[$3488, $3489]))/((2 - X1)*(1 - X1^2)*X7^3) - ((2*X4^2*X6^2 -
+X1*X4^2*X6^2 - X4^2*X5*X7 - 2*X3*X4*X6*X7 + 2*X1*X3*X4*X6*X7 - X2*X6^2*X7 +
+X3^2*X7^2 - X1*X3^2*X7^2 + X2*X5*X7^2)*(KDD[$3047, $3489]*KDD[$3050, $3488] +
+KDD[$3047, $3050]*KDD[$3488, $3489]))/((2 - X1)*(1 - X1^2)*X7^2)}"},
 {"fcstCTdec-ID12",
 "CTdec[{{l,i1},{l,i2},{l,i3}},{},UseTIDL\[Rule]False,List\[Rule]\
 False]", "0"},
@@ -182,64 +175,75 @@ mu3]*KDD[mu4, mu5]))/((1 - (-1 + D)^2)*CSPD[k1, k1]^3)"},
 {"fcstCTdec-ID16",
 "CTdec[{{q1,$3050},{q1,$3489},{q2,$3047},{q2,$3488}},{k1},\
 Dimension\[Rule]D-1,List\[Rule]False,UseTIDL\[Rule]False,FCE\[Rule]\
-True]", "-(((8*CSPD[k1, q1]^2*CSPD[k1, q2]^2 + 6*(-1 + D)*CSPD[k1, \
-q1]^2*CSPD[k1, q2]^2 + (-1 + D)^2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - \
-2*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - (-1 + D)*CSPD[k1, \
-k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - 8*CSPD[k1, k1]*CSPD[k1, \
-q1]*CSPD[k1, q2]*CSPD[q1, q2] - 4*(-1 + D)*CSPD[k1, k1]*CSPD[k1, \
-q1]*CSPD[k1, q2]*CSPD[q1, q2] + 2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 - \
-2*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*CSPD[k1, \
-k1]*CSPD[k1, q1]^2*CSPD[q2, q2] + CSPD[k1, k1]^2*CSPD[q1, \
-q1]*CSPD[q2, q2])*CVD[k1, $3047]*CVD[k1, $3050]*CVD[k1, \
-$3488]*CVD[k1, $3489])/((1 - (-1 + D)^2)*CSPD[k1, k1]^4)) + \
-((4*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)^2*CSPD[k1, \
-q1]^2*CSPD[k1, q2]^2 + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, \
-q1] - 4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] + \
-2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 - 2*CSPD[k1, k1]*CSPD[k1, \
-q1]^2*CSPD[q2, q2] + (-1 + D)^2*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, \
-q2] - (-1 + D)*CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*CVD[k1, \
-$3050]*CVD[k1, $3489]*KDD[$3047, $3488])/((1 - (-1 + D)^2)*(3 - \
-D)*CSPD[k1, k1]^3) + ((4*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + \
-D)^2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - CSPD[k1, k1]*CSPD[k1, \
-q2]^2*CSPD[q1, q1] - 4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, \
-q2]*CSPD[q1, q2] + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, \
-q2]*CSPD[q1, q2] + (-1 + D)^2*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, \
-q2]*CSPD[q1, q2] + CSPD[k1, k1]^2*CSPD[q1, q2]^2 - (-1 + D)*CSPD[k1, \
-k1]^2*CSPD[q1, q2]^2 - CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] + \
-CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*(CVD[k1, $3488]*CVD[k1, \
-$3489]*KDD[$3047, $3050] + CVD[k1, $3050]*CVD[k1, $3488]*KDD[$3047, \
-$3489]))/((1 - (-1 + D)^2)*(3 - D)*CSPD[k1, k1]^3) + ((4*CSPD[k1, \
-q1]^2*CSPD[k1, q2]^2 - (-1 + D)^2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - \
-2*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] + (-1 + D)^2*CSPD[k1, \
-k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - 4*CSPD[k1, k1]*CSPD[k1, \
-q1]*CSPD[k1, q2]*CSPD[q1, q2] + 2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 + (-1 \
-+ D)*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*CSPD[k1, \
-k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*CVD[k1, $3047]*CVD[k1, \
-$3488]*KDD[$3050, $3489])/((1 - (-1 + D)^2)*(3 - D)*CSPD[k1, k1]^3) - \
-((2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)*CSPD[k1, q1]^2*CSPD[k1, \
-q2]^2 + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - \
-4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] + 2*CSPD[k1, \
-k1]^2*CSPD[q1, q2]^2 + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, \
-q2] - (-1 + D)*CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*KDD[$3047, \
-$3488]*KDD[$3050, $3489])/((1 - (-1 + D)^2)*(3 - D)*CSPD[k1, k1]^2) + \
-((4*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)^2*CSPD[k1, \
-q1]^2*CSPD[k1, q2]^2 - CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - \
-4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] + (-1 + \
-D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] + (-1 + \
-D)^2*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] + CSPD[k1, \
-k1]^2*CSPD[q1, q2]^2 - (-1 + D)*CSPD[k1, k1]^2*CSPD[q1, q2]^2 - \
-CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] + CSPD[k1, k1]^2*CSPD[q1, \
-q1]*CSPD[q2, q2])*(CVD[k1, $3047]*CVD[k1, $3489]*KDD[$3050, $3488] + \
-CVD[k1, $3047]*CVD[k1, $3050]*KDD[$3488, $3489]))/((1 - (-1 + \
-D)^2)*(3 - D)*CSPD[k1, k1]^3) - ((2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - \
-(-1 + D)*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - CSPD[k1, k1]*CSPD[k1, \
-q2]^2*CSPD[q1, q1] - 2*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, \
-q2]*CSPD[q1, q2] + 2*(-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, \
-q2]*CSPD[q1, q2] + CSPD[k1, k1]^2*CSPD[q1, q2]^2 - (-1 + D)*CSPD[k1, \
-k1]^2*CSPD[q1, q2]^2 - CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] + \
-CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*(KDD[$3047, \
-$3489]*KDD[$3050, $3488] + KDD[$3047, $3050]*KDD[$3488, $3489]))/((1 \
-- (-1 + D)^2)*(3 - D)*CSPD[k1, k1]^2)"}
+True]", "-(((8*CSPD[k1, q1]^2*CSPD[k1, q2]^2 +
+		6*(-1 + D)*CSPD[k1, q1]^2*CSPD[k1, q2]^2 + (-1 + D)^2*
+		 CSPD[k1, q1]^2*CSPD[k1, q2]^2 -
+		2*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] - (-1 + D)*
+		 CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] -
+		8*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] -
+		4*(-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*
+		 CSPD[q1, q2] + 2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 -
+		2*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*
+		 CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] +
+		CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*CVD[k1, $3047]*
+	  CVD[k1, $3050]*CVD[k1, $3488]*CVD[k1, $3489])/((1 - (-1 + D)^2)*
+	  CSPD[k1, k1]^4)) + ((4*CSPD[k1, q1]^2*
+	   CSPD[k1, q2]^2 - (-1 + D)^2*CSPD[k1, q1]^2*
+	   CSPD[k1, q2]^2 + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q2]^2*
+	   CSPD[q1, q1] -
+	  4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] +
+	  2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 -
+	  2*CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] + (-1 + D)^2*
+	   CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*
+	   CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*CVD[k1, $3050]*
+	CVD[k1, $3489]*KDD[$3047, $3488])/((1 - (-1 + D)^2)*(3 - D)*
+	CSPD[k1,
+	  k1]^3) + ((4*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)^2*
+	   CSPD[k1, q1]^2*CSPD[k1, q2]^2 -
+	  2*CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] + (-1 + D)^2*
+	   CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] -
+	  4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] +
+	  2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 + (-1 + D)*CSPD[k1, k1]*
+	   CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*CSPD[k1, k1]^2*
+	   CSPD[q1, q1]*CSPD[q2, q2])*CVD[k1, $3047]*CVD[k1, $3488]*
+	KDD[$3050, $3489])/((1 - (-1 + D)^2)*(3 - D)*
+	CSPD[k1,
+	  k1]^3) - ((2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)*
+	   CSPD[k1, q1]^2*CSPD[k1, q2]^2 + (-1 + D)*CSPD[k1, k1]*
+	   CSPD[k1, q2]^2*CSPD[q1, q1] -
+	  4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] +
+	  2*CSPD[k1, k1]^2*CSPD[q1, q2]^2 + (-1 + D)*CSPD[k1, k1]*
+	   CSPD[k1, q1]^2*CSPD[q2, q2] - (-1 + D)*CSPD[k1, k1]^2*
+	   CSPD[q1, q1]*CSPD[q2, q2])*KDD[$3047, $3488]*
+	KDD[$3050, $3489])/((1 - (-1 + D)^2)*(3 - D)*
+	CSPD[k1,
+	  k1]^2) + ((4*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)^2*
+	   CSPD[k1, q1]^2*CSPD[k1, q2]^2 -
+	  CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] -
+	  4*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*
+	   CSPD[q1, q2] + (-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*
+	   CSPD[q1, q2] + (-1 + D)^2*CSPD[k1, k1]*CSPD[k1, q1]*
+	   CSPD[k1, q2]*CSPD[q1, q2] +
+	  CSPD[k1, k1]^2*CSPD[q1, q2]^2 - (-1 + D)*CSPD[k1, k1]^2*
+	   CSPD[q1, q2]^2 - CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] +
+	  CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*(CVD[k1, $3488]*
+	   CVD[k1, $3489]*KDD[$3047, $3050] +
+	  CVD[k1, $3050]*CVD[k1, $3488]*KDD[$3047, $3489] +
+	  CVD[k1, $3047]*CVD[k1, $3489]*KDD[$3050, $3488] +
+	  CVD[k1, $3047]*CVD[k1, $3050]*
+	   KDD[$3488, $3489]))/((1 - (-1 + D)^2)*(3 - D)*
+	CSPD[k1,
+	  k1]^3) - ((2*CSPD[k1, q1]^2*CSPD[k1, q2]^2 - (-1 + D)*
+	   CSPD[k1, q1]^2*CSPD[k1, q2]^2 -
+	  CSPD[k1, k1]*CSPD[k1, q2]^2*CSPD[q1, q1] -
+	  2*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] +
+	  2*(-1 + D)*CSPD[k1, k1]*CSPD[k1, q1]*CSPD[k1, q2]*CSPD[q1, q2] +
+	   CSPD[k1, k1]^2*CSPD[q1, q2]^2 - (-1 + D)*CSPD[k1, k1]^2*
+	   CSPD[q1, q2]^2 - CSPD[k1, k1]*CSPD[k1, q1]^2*CSPD[q2, q2] +
+	  CSPD[k1, k1]^2*CSPD[q1, q1]*CSPD[q2, q2])*(KDD[$3047, $3489]*
+	   KDD[$3050, $3488] +
+	  KDD[$3047, $3050]*KDD[$3488, $3489]))/((1 - (-1 + D)^2)*(3 - D)*
+	CSPD[k1, k1]^2)"}
 });
 
 

--- a/Tests/LoopIntegrals/Tdec.test
+++ b/Tests/LoopIntegrals/Tdec.test
@@ -69,23 +69,67 @@ UseParallelization -> False, List -> False]","-(((FVD[k1, mu1]*MTD[mu2, mu5]*MTD
 	4*D*SPD[k1, k1]*SPD[k1, q1]^3*SPD[q1, q2] + 12*SPD[k1, k1]^2*SPD[k1, q1]*SPD[q1, q1]*SPD[q1, q2]))/((1 - D^2)*SPD[k1, k1]^5)"},
 {"fcstTdec-ID16","Tdec[{{q1, $3050}, {q1, $3489}, {q2, $3047}, {q2, $3488}}, {k1},
 Dimension -> D, List -> False, UseTIDL -> False, FCE -> True]",
-"-(((MTD[$3047, $3489]*MTD[$3050, $3488] + MTD[$3047, $3050]*MTD[$3488, $3489])*(2*SPD[k1, q1]^2*SPD[k1, q2]^2 - D*SPD[k1, q1]^2*SPD[k1, q2]^2 - SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
-	2*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + 2*D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + SPD[k1, k1]^2*SPD[q1, q2]^2 - D*SPD[k1, k1]^2*SPD[q1, q2]^2 - SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] +
-	SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*SPD[k1, k1]^2)) + ((FVD[k1, $3488]*FVD[k1, $3489]*MTD[$3047, $3050] + FVD[k1, $3050]*FVD[k1, $3488]*MTD[$3047, $3489])*
-(4*SPD[k1, q1]^2*SPD[k1, q2]^2 - D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 - SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - 4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
-	D^2*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + SPD[k1, k1]^2*SPD[q1, q2]^2 - D*SPD[k1, k1]^2*SPD[q1, q2]^2 - SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] + SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/
-((2 - D)*(1 - D^2)*SPD[k1, k1]^3) + ((FVD[k1, $3047]*FVD[k1, $3489]*MTD[$3050, $3488] + FVD[k1, $3047]*FVD[k1, $3050]*MTD[$3488, $3489])*
-(4*SPD[k1, q1]^2*SPD[k1, q2]^2 - D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 - SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - 4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
-	D^2*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + SPD[k1, k1]^2*SPD[q1, q2]^2 - D*SPD[k1, k1]^2*SPD[q1, q2]^2 - SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] + SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/
-((2 - D)*(1 - D^2)*SPD[k1, k1]^3) - (FVD[k1, $3047]*FVD[k1, $3050]*FVD[k1, $3488]*FVD[k1, $3489]*(8*SPD[k1, q1]^2*SPD[k1, q2]^2 + 6*D*SPD[k1, q1]^2*SPD[k1, q2]^2 + D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 -
-	2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - 8*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] - 4*D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
-	2*SPD[k1, k1]^2*SPD[q1, q2]^2 - 2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] - D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] + SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((1 - D^2)*SPD[k1, k1]^4) -
-(MTD[$3047, $3488]*MTD[$3050, $3489]*(2*SPD[k1, q1]^2*SPD[k1, q2]^2 - D*SPD[k1, q1]^2*SPD[k1, q2]^2 + D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - 4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
-	2*SPD[k1, k1]^2*SPD[q1, q2]^2 + D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] - D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*SPD[k1, k1]^2) +
-(FVD[k1, $3047]*FVD[k1, $3488]*MTD[$3050, $3489]*(4*SPD[k1, q1]^2*SPD[k1, q2]^2 - D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 - 2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] + D^2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
-	4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] + 2*SPD[k1, k1]^2*SPD[q1, q2]^2 + D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] - D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*SPD[k1, k1]^3) +
-(FVD[k1, $3050]*FVD[k1, $3489]*MTD[$3047, $3488]*(4*SPD[k1, q1]^2*SPD[k1, q2]^2 - D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 + D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] - 4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
-	2*SPD[k1, k1]^2*SPD[q1, q2]^2 - 2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] + D^2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] - D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*SPD[k1, k1]^3)"},
+"-(((MTD[$3047, $3489]*MTD[$3050, $3488] +
+		MTD[$3047, $3050]*MTD[$3488, $3489])*(2*SPD[k1, q1]^2*
+		 SPD[k1, q2]^2 - D*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+		SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+		2*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+		2*D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+		SPD[k1, k1]^2*SPD[q1, q2]^2 - D*SPD[k1, k1]^2*SPD[q1, q2]^2 -
+		SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] +
+		SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*
+	  SPD[k1, k1]^2)) + ((FVD[k1, $3488]*FVD[k1, $3489]*
+	   MTD[$3047, $3050] +
+	  FVD[k1, $3050]*FVD[k1, $3488]*MTD[$3047, $3489] +
+	  FVD[k1, $3047]*FVD[k1, $3489]*MTD[$3050, $3488] +
+	  FVD[k1, $3047]*FVD[k1, $3050]*MTD[$3488, $3489])*(4*
+	   SPD[k1, q1]^2*SPD[k1, q2]^2 - D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	   SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  D^2*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  SPD[k1, k1]^2*SPD[q1, q2]^2 - D*SPD[k1, k1]^2*SPD[q1, q2]^2 -
+	  SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] +
+	  SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*
+	SPD[k1, k1]^3) - (FVD[k1, $3047]*FVD[k1, $3050]*FVD[k1, $3488]*
+	FVD[k1, $3489]*(8*SPD[k1, q1]^2*SPD[k1, q2]^2 +
+	  6*D*SPD[k1, q1]^2*SPD[k1, q2]^2 +
+	  D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	  2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  8*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] -
+	  4*D*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  2*SPD[k1, k1]^2*SPD[q1, q2]^2 -
+	  2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] -
+	  D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] +
+	  SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((1 - D^2)*
+	SPD[k1, k1]^4) - (MTD[$3047, $3488]*
+	MTD[$3050, $3489]*(2*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	  D*SPD[k1, q1]^2*SPD[k1, q2]^2 +
+	  D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  2*SPD[k1, k1]^2*SPD[q1, q2]^2 +
+	  D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] -
+	  D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*
+	SPD[k1, k1]^2) + (FVD[k1, $3047]*FVD[k1, $3488]*
+	MTD[$3050, $3489]*(4*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	  D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	  2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] +
+	  D^2*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  2*SPD[k1, k1]^2*SPD[q1, q2]^2 +
+	  D*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] -
+	  D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*
+	SPD[k1, k1]^3) + (FVD[k1, $3050]*FVD[k1, $3489]*
+	MTD[$3047, $3488]*(4*SPD[k1, q1]^2*SPD[k1, q2]^2 -
+	  D^2*SPD[k1, q1]^2*SPD[k1, q2]^2 +
+	  D*SPD[k1, k1]*SPD[k1, q2]^2*SPD[q1, q1] -
+	  4*SPD[k1, k1]*SPD[k1, q1]*SPD[k1, q2]*SPD[q1, q2] +
+	  2*SPD[k1, k1]^2*SPD[q1, q2]^2 -
+	  2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] +
+	  D^2*SPD[k1, k1]*SPD[k1, q1]^2*SPD[q2, q2] -
+	  D*SPD[k1, k1]^2*SPD[q1, q1]*SPD[q2, q2]))/((2 - D)*(1 - D^2)*
+	SPD[k1, k1]^3)"},
 {"fcstTdec-ID17","Tdec[{{l, i1}, {l, i2}}, {p1}, Head -> mom]",
 	"{{X1 -> D, X2 -> SPD[l, l], X3 -> SPD[l, mom[p1]],
 X4 -> SPD[mom[p1],


### PR DESCRIPTION
Using the symmetrization algorithm of A. Pak from arXiv:1111.0868 makes
Tdec much faster by drastically reducing the size of linear equations that
need to be solved (in some cases, but especially for higher ranks).

Todo:

- [x] Refactor the code of Tdec to make it easier to maintain
- [ ] Regenerate TIDL entries to benefit from the shorter expressions that stem from the new symmetrizer (in some cases)
- [ ] Create a separate GitHub repository for large decompositions
- [x] Add an option to disable the symmetrizer (useful for debugging)
- [ ] Backport to stable, since the old symmetrizer may completely fail in some cases