### PR TITLE
FCLoopBasisIntegralToGraph: Graph representation from a propagator representation

### DIFF
--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/FCLoopIntegralToGraph.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/FCLoopIntegralToGraph.nb
@@ -1,0 +1,810 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 10.4' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     24005,        802]
+NotebookOptionsPosition[     19504,        641]
+NotebookOutlinePosition[     20118,        665]
+CellTagsIndexPosition[     20039,        660]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[TextData[{
+ "New in: ",
+ Cell["9.3", "HistoryData",
+  CellTags->"New"],
+ " | Modified in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Modified"],
+ " | Obsolete in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Obsolete"],
+ " | Excised in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Excised"]
+}], "History",
+ CellID->1247902091],
+
+Cell[CellGroupData[{
+
+Cell["Categorization", "CategorizationSection",
+ CellID->1122911449],
+
+Cell["Symbol", "Categorization",
+ CellLabel->"Entity Type",
+ CellID->686433507],
+
+Cell["FeynCalc", "Categorization",
+ CellLabel->"Paclet Name",
+ CellID->605800465],
+
+Cell["FeynCalc`", "Categorization",
+ CellLabel->"Context",
+ CellID->468444828],
+
+Cell["FeynCalc/ref/FCLoopIntegralToGraph", "Categorization",
+ CellLabel->"URI"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Keywords", "KeywordsSection",
+ CellID->477174294],
+
+Cell["XXXX", "Keywords",
+ CellID->1164421360]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Syntax Templates", "TemplatesSection",
+ CellID->1872225408],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Additional Function Template",
+ CellID->1562036412],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Arguments Pattern",
+ CellID->158391909],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Local Variables",
+ CellID->1360575930],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Color Equal Signs",
+ CellID->793782254]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Details", "DetailsSection",
+ CellID->307771771],
+
+Cell["XXXX", "Details",
+ CellLabel->"Lead",
+ CellID->670882175],
+
+Cell["XXXX", "Details",
+ CellLabel->"Developers",
+ CellID->350963985],
+
+Cell["XXXX", "Details",
+ CellLabel->"Authors",
+ CellID->8391405],
+
+Cell["XXXX", "Details",
+ CellLabel->"Feature Name",
+ CellID->3610269],
+
+Cell["XXXX", "Details",
+ CellLabel->"QA",
+ CellID->401364205],
+
+Cell["XXXX", "Details",
+ CellLabel->"DA",
+ CellID->350204745],
+
+Cell["XXXX", "Details",
+ CellLabel->"Docs",
+ CellID->732958810],
+
+Cell["XXXX", "Details",
+ CellLabel->"Features Page Notes",
+ CellID->222905350],
+
+Cell["XXXX", "Details",
+ CellLabel->"Comments",
+ CellID->240026365]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["FCLoopIntegralToGraph", "ObjectName",
+ CellID->1224892054],
+
+Cell[TextData[{
+ Cell["   ", "ModInfo"],
+ Cell[BoxData[
+  RowBox[{"FCLoopIntegralToGraph", "[", 
+   RowBox[{"int", ",", 
+    RowBox[{"{", 
+     RowBox[{"q1", ",", "q2", ",", "..."}], "}"}]}], "]"}]], 
+  "InlineFormula"],
+ " \[LineSeparator]constructs a graph representation of the loop integral int \
+that depends on the loop momenta q1, q2, .... The function returns a list of \
+the form {edges,labels,props,pref}, where edges is a list of edge rules \
+representing the loop integral int, labels is a list of lists containing the \
+line momentum, multiplicity and the mass term of each propagator, props is a \
+list with the original propagators and pref is the piece of the integral that \
+was ignored when constructing the graph representation (e.g. scalar products \
+or vectors in the numerator) A quick and simple way to plot the graph is to \
+evaluate GraphPlot[List @@@ Transpose[output[[1 ;; 2]]]] or GraphPlot[Labeled \
+@@@ Transpose[output[[1 ;; 2]]]]. The visual quality will not be that great, \
+though. To obtain a nicer plot one might use GraphPlot with a custom \
+EdgeTaggedGraph or export the output to a file and visualize it with an \
+external tool such as dot/neato from graphviz."
+}], "Usage",
+ CellChangeTimes->{{3.824442016314081*^9, 3.824442045358575*^9}, {
+  3.824442274191391*^9, 3.824442297393857*^9}},
+ CellID->982511436],
+
+Cell["XXXX", "Notes",
+ CellID->1067943069]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Tutorials", "TutorialsSection",
+ CellID->250839057],
+
+Cell["XXXX", "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Demonstrations", "RelatedDemonstrationsSection",
+ CellID->1268215905],
+
+Cell["XXXX", "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Links", "RelatedLinksSection",
+ CellID->1584193535],
+
+Cell["XXXX", "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["See Also", "SeeAlsoSection",
+ CellID->1255426704],
+
+Cell["XXXX", "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More About", "MoreAboutSection",
+ CellID->38303248],
+
+Cell["XXXX", "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[GridBox[{
+    {
+     StyleBox["Examples", "PrimaryExamplesSection"], 
+     ButtonBox[
+      RowBox[{
+       RowBox[{"More", " ", "Examples"}], " ", "\[RightTriangle]"}],
+      BaseStyle->"ExtendedExamplesLink",
+      ButtonData:>"ExtendedExamples"]}
+   }],
+  $Line = 0; Null]], "PrimaryExamplesSection",
+ CellID->880084151],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"out", "=", 
+  RowBox[{"FCLoopIntegralToGraph", "[", " ", 
+   RowBox[{
+    RowBox[{"FAD", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"q", "-", "k1"}], "}"}], ",", "k1", ",", 
+      RowBox[{"q", "-", "k2"}], ",", "k2", ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"k2", "-", "k3"}], ",", "mb"}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"k1", "-", "k3"}], ",", "mb"}], "}"}]}], "]"}], ",", 
+    RowBox[{"{", 
+     RowBox[{"k1", ",", "k2", ",", "k3"}], "}"}]}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.824442077227489*^9, 3.824442077946327*^9}},
+ CellLabel->"In[5]:=",
+ CellID->1714855831],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"{", 
+   RowBox[{
+    RowBox[{"{", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"-", "3"}], "\[Rule]", "2"}], ",", 
+      RowBox[{
+       RowBox[{"-", "1"}], "\[Rule]", "1"}], ",", 
+      RowBox[{"1", "\[Rule]", "3"}], ",", 
+      RowBox[{"1", "\[Rule]", "4"}], ",", 
+      RowBox[{"2", "\[Rule]", "3"}], ",", 
+      RowBox[{"2", "\[Rule]", "4"}], ",", 
+      RowBox[{"3", "\[Rule]", "4"}], ",", 
+      RowBox[{"3", "\[Rule]", "4"}]}], "}"}], ",", 
+    RowBox[{"{", 
+     RowBox[{"q", ",", "q", ",", 
+      RowBox[{"{", 
+       RowBox[{"k2", ",", "1", ",", "0"}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"q", "-", "k2"}], ",", "1", ",", "0"}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"k1", ",", "1", ",", "0"}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"q", "-", "k1"}], ",", "1", ",", "0"}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"k2", "-", "k3"}], ",", "1", ",", 
+        RowBox[{"-", 
+         SuperscriptBox["mb", "2"]}]}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"k1", "-", "k3"}], ",", "1", ",", 
+        RowBox[{"-", 
+         SuperscriptBox["mb", "2"]}]}], "}"}]}], "}"}], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",SuperscriptBox[
+         FormBox[
+          FormBox["k2", TraditionalForm], TraditionalForm], 2],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",SuperscriptBox[
+         FormBox[
+          FormBox["k1", TraditionalForm], TraditionalForm], 2],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",RowBox[{
+          SuperscriptBox[
+           RowBox[{
+             FormBox["\"(\"", TraditionalForm], 
+             FormBox[
+              FormBox[
+               RowBox[{
+                 FormBox["q", TraditionalForm], "-", 
+                 FormBox["k2", TraditionalForm]}], TraditionalForm], 
+              TraditionalForm], 
+             FormBox["\")\"", TraditionalForm]}], 2]}],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",RowBox[{
+          SuperscriptBox[
+           RowBox[{
+             FormBox["\"(\"", TraditionalForm], 
+             FormBox[
+              FormBox[
+               RowBox[{
+                 FormBox["q", TraditionalForm], "-", 
+                 FormBox["k1", TraditionalForm]}], TraditionalForm], 
+              TraditionalForm], 
+             FormBox["\")\"", TraditionalForm]}], 2]}],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",RowBox[{
+          SuperscriptBox[
+           RowBox[{
+             FormBox["\"(\"", TraditionalForm], 
+             FormBox[
+              FormBox[
+               RowBox[{
+                 FormBox["k2", TraditionalForm], "-", 
+                 FormBox["k3", TraditionalForm]}], TraditionalForm], 
+              TraditionalForm], 
+             FormBox["\")\"", TraditionalForm]}], 2]}],RowBox[{"-", 
+          SuperscriptBox["mb", "2"]}],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", 
+    FormBox[
+     FractionBox["1", 
+      TemplateBox[{"\"(\"",RowBox[{
+          SuperscriptBox[
+           RowBox[{
+             FormBox["\"(\"", TraditionalForm], 
+             FormBox[
+              FormBox[
+               RowBox[{
+                 FormBox["k1", TraditionalForm], "-", 
+                 FormBox["k3", TraditionalForm]}], TraditionalForm], 
+              TraditionalForm], 
+             FormBox["\")\"", TraditionalForm]}], 2]}],RowBox[{"-", 
+          SuperscriptBox["mb", "2"]}],"\"+\"",
+        RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+       "RowDefault"]],
+     TraditionalForm], ",", "1"}], "}"}], TraditionalForm]], "Output",
+ CellChangeTimes->{
+  3.824442078932123*^9, {3.824442116636261*^9, 3.824442135720689*^9}, 
+   3.824442174530336*^9},
+ CellLabel->"Out[5]=",
+ CellID->1526753115]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"Labeled", "@@@", 
+   RowBox[{"Transpose", "[", 
+    RowBox[{"out", "[", 
+     RowBox[{"[", 
+      RowBox[{"1", ";;", "2"}], "]"}], "]"}], "]"}]}], "//", 
+  "InputForm"}]], "Input",
+ CellChangeTimes->{{3.824442182400002*^9, 3.824442196314022*^9}},
+ CellLabel->"In[9]:=",
+ CellID->1025428144],
+
+Cell["\<\
+{Labeled[-3 -> 2, q], Labeled[-1 -> 1, q], Labeled[1 -> 3, {k2, 1, 0}], \
+Labeled[1 -> 4, {-k2 + q, 1, 0}], 
+ Labeled[2 -> 3, {k1, 1, 0}], Labeled[2 -> 4, {-k1 + q, 1, 0}], Labeled[3 -> \
+4, {k2 - k3, 1, -mb^2}], 
+ Labeled[3 -> 4, {k1 - k3, 1, -mb^2}]}\
+\>", "Output",
+ CellChangeTimes->{{3.824442175895096*^9, 3.8244421966178017`*^9}},
+ CellLabel->"Out[9]//InputForm=",
+ CellID->940365462]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"GraphPlot", "[", 
+  RowBox[{"List", "@@@", 
+   RowBox[{"Transpose", "[", 
+    RowBox[{"out", "[", 
+     RowBox[{"[", 
+      RowBox[{"1", ";;", "2"}], "]"}], "]"}], "]"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.824442137994632*^9, 3.8244421620498657`*^9}, {
+  3.8244422550607367`*^9, 3.8244422554930897`*^9}},
+ CellLabel->"In[12]:=",
+ CellID->1688284977],
+
+Cell[BoxData[
+ FormBox[
+  GraphicsBox[
+   TagBox[GraphicsComplexBox[CompressedData["
+1:eJxTTMoPSmViYGBQA2IQDQML//H5ZLy7Yn/+j4UDV8hH+xqPLPNfr67Y7/v8
+oKS/VMDB/ErPlOwPV+wPnT4aMN2dw4Fdd0Mv67Mr9tssluWEVzI4wMw5N6ty
+4jwg33t+hVPp/Sf2c47Eff4ZxuDwKWGj6EKjjfZm/x7UZ/sxOJwvCb024dJW
++xyvuac13Rkc7imaTY+u3mV/+O1fGXNHBod9pW3J3dr77RfVpwROtWFwiM6o
+/XX5w0H7f/ZT7rhaMjhk2z6YIu13xP5+p+0JT3MGhyD11r331hyzj2xftXmh
+GYOD53I2q3iek/YnH57W2Afk355vcOmzxV37+tnrgD5jcFB2qq/fnHHP3q9Y
+ID0LaJ79eY1E4Rn37TP4kx/vBdq3Js1RNyr5gX32hk2bkoHuES+MOyr964H9
+jUc/46OA7p1/w99UfsJD+47CaTwLgP7pviheaqr6yL695H6BUTiDQ4Kq6HH9
+nY/s/8U59B6ezeBQd176tjbQ/38SOz+GLmFw0Mxjy/53cav9mg+q82avZnBo
+MHXL3FC1y15SOdd70kYGh1OFF1+c1tpvL3Nkj5TFNqD5j+6E5AD9b5bAP717
+J4PD/nsT3Nf5HrFntSjc2r2bweHHj8dceUD/7/4YfNV8D4NDp21j6lvuk/ba
+PqVeIUD+71dvn+8C+n+p5yPTNUD131fpqVUD/d82uVtxA9C8l/KNu+5Mv2//
+MHj3mgSgfZauN50dgP4/9FTx4T6ge2ZcYL/GDPS/RGeT0Rmge0VuTzzPCfS/
+31W7ui6gf7Z+WKuuDPT/c76DXH+A/jUsPiSvCPQ/AEiwFME=
+     "], {
+      {RGBColor[0.5, 0., 0.], 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox["q", StripOnInput -> False], TraditionalForm]], {0, 
+              0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{1, 2}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{"k1", ",", "1", ",", "0"}], "}"}], StripOnInput -> 
+                 False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{2, 5}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"q", "-", "k1"}], ",", "1", ",", "0"}], "}"}], 
+                 StripOnInput -> False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{2, 6}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox["q", StripOnInput -> False], TraditionalForm]], {0, 
+              0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{3, 4}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{"k2", ",", "1", ",", "0"}], "}"}], StripOnInput -> 
+                 False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{4, 5}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"q", "-", "k2"}], ",", "1", ",", "0"}], "}"}], 
+                 StripOnInput -> False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], ArrowBox[{4, 6}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"k2", "-", "k3"}], ",", "1", ",", 
+                    RowBox[{"-", 
+                    SuperscriptBox["mb", "2"]}]}], "}"}], StripOnInput -> 
+                 False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], 
+        ArrowBox[{5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 
+         22, 6}]}, 
+       {Arrowheads[{{0.5, 0.5, 
+           GraphicsBox[{
+             GrayLevel[0], 
+             InsetBox[
+              BoxData[
+               FormBox[
+                StyleBox[
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"k1", "-", "k3"}], ",", "1", ",", 
+                    RowBox[{"-", 
+                    SuperscriptBox["mb", "2"]}]}], "}"}], StripOnInput -> 
+                 False], TraditionalForm]], {0, 0}, 
+              ImageScaled[{0.5, 0.5}], Automatic, None, Background -> 
+              GrayLevel[1]]}]}, {0, 0}}], 
+        ArrowBox[{5, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 
+         37, 38, 6}]}}, 
+      {RGBColor[0, 0, 0.7], 
+       TagBox[
+        TooltipBox[PointBox[1],
+         RowBox[{"-", "3"}]],
+        Annotation[#, -3, "Tooltip"]& ], 
+       TagBox[
+        TooltipBox[PointBox[2],
+         "2"],
+        Annotation[#, 2, "Tooltip"]& ], 
+       TagBox[
+        TooltipBox[PointBox[3],
+         RowBox[{"-", "1"}]],
+        Annotation[#, -1, "Tooltip"]& ], 
+       TagBox[
+        TooltipBox[PointBox[4],
+         "1"],
+        Annotation[#, 1, "Tooltip"]& ], 
+       TagBox[
+        TooltipBox[PointBox[5],
+         "3"],
+        Annotation[#, 3, "Tooltip"]& ], 
+       TagBox[
+        TooltipBox[PointBox[6],
+         "4"],
+        Annotation[#, 4, "Tooltip"]& ]}}],
+    Annotation[#, 
+     VertexCoordinateRules -> {{0., 0.32705123355479243`}, {1.083017588491021,
+       0.3268418828166728}, {4.1148050558376195`, 0.3271740866360377}, {
+      3.0349565801966216`, 0.3265394099878027}, {2.0592487800814423`, 0.}, {
+      2.0593844762073337`, 0.6522775934472319}}]& ],
+   AspectRatio->Automatic,
+   FrameTicks->None,
+   ImageSize->{397.33333333333286`, Automatic},
+   PlotRange->All,
+   PlotRangePadding->Scaled[0.1]], TraditionalForm]], "Output",
+ CellChangeTimes->{{3.824442154688785*^9, 3.824442179882958*^9}, {
+  3.824442255870178*^9, 3.824442264839971*^9}},
+ CellLabel->"Out[12]=",
+ CellID->1808823346]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More Examples", "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Scope", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1293636265],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Generalizations & Extensions", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1020263627],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["Options", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2061341341],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1757724783],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Applications", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->258228157],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Properties & Relations", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2123667759],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Possible Issues", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1305812373],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Interactive Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1653164318],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Neat Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+},
+WindowSize->{700, 770},
+WindowMargins->{{2492, Automatic}, {Automatic, 171}},
+CellContext->"Global`",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
+StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
+  CharacterEncoding -> "UTF-8"]
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "ExtendedExamples"->{
+  Cell[17984, 583, 100, 2, 42, "ExtendedExamplesSection",
+   CellTags->"ExtendedExamples",
+   CellID->1854448968]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"ExtendedExamples", 19900, 653}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 325, 14, 19, "History",
+ CellID->1247902091],
+Cell[CellGroupData[{
+Cell[908, 38, 68, 1, 22, "CategorizationSection",
+ CellID->1122911449],
+Cell[979, 41, 79, 2, 70, "Categorization",
+ CellID->686433507],
+Cell[1061, 45, 81, 2, 70, "Categorization",
+ CellID->605800465],
+Cell[1145, 49, 78, 2, 70, "Categorization",
+ CellID->468444828],
+Cell[1226, 53, 79, 1, 70, "Categorization"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1342, 59, 55, 1, 15, "KeywordsSection",
+ CellID->477174294],
+Cell[1400, 62, 45, 1, 70, "Keywords",
+ CellID->1164421360]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1482, 68, 65, 1, 15, "TemplatesSection",
+ CellID->1872225408],
+Cell[1550, 71, 94, 2, 70, "Template",
+ CellID->1562036412],
+Cell[1647, 75, 82, 2, 70, "Template",
+ CellID->158391909],
+Cell[1732, 79, 81, 2, 70, "Template",
+ CellID->1360575930],
+Cell[1816, 83, 82, 2, 70, "Template",
+ CellID->793782254]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1935, 90, 53, 1, 15, "DetailsSection",
+ CellID->307771771],
+Cell[1991, 93, 63, 2, 70, "Details",
+ CellID->670882175],
+Cell[2057, 97, 69, 2, 70, "Details",
+ CellID->350963985],
+Cell[2129, 101, 64, 2, 70, "Details",
+ CellID->8391405],
+Cell[2196, 105, 69, 2, 70, "Details",
+ CellID->3610269],
+Cell[2268, 109, 61, 2, 70, "Details",
+ CellID->401364205],
+Cell[2332, 113, 61, 2, 70, "Details",
+ CellID->350204745],
+Cell[2396, 117, 63, 2, 70, "Details",
+ CellID->732958810],
+Cell[2462, 121, 78, 2, 70, "Details",
+ CellID->222905350],
+Cell[2543, 125, 67, 2, 70, "Details",
+ CellID->240026365]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[2647, 132, 64, 1, 48, "ObjectName",
+ CellID->1224892054],
+Cell[2714, 135, 1348, 24, 196, "Usage",
+ CellID->982511436],
+Cell[4065, 161, 42, 1, 19, "Notes",
+ CellID->1067943069]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4144, 167, 57, 1, 35, "TutorialsSection",
+ CellID->250839057],
+Cell[4204, 170, 45, 1, 15, "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4286, 176, 83, 1, 25, "RelatedDemonstrationsSection",
+ CellID->1268215905],
+Cell[4372, 179, 58, 1, 15, "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4467, 185, 65, 1, 25, "RelatedLinksSection",
+ CellID->1584193535],
+Cell[4535, 188, 49, 1, 15, "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4621, 194, 55, 1, 25, "SeeAlsoSection",
+ CellID->1255426704],
+Cell[4679, 197, 43, 1, 15, "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4759, 203, 57, 1, 25, "MoreAboutSection",
+ CellID->38303248],
+Cell[4819, 206, 46, 1, 15, "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[4902, 212, 356, 11, 53, "PrimaryExamplesSection",
+ CellID->880084151],
+Cell[CellGroupData[{
+Cell[5283, 227, 660, 19, 48, "Input",
+ CellID->1714855831],
+Cell[5946, 248, 4394, 124, 142, "Output",
+ CellID->1526753115]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[10377, 377, 325, 10, 20, "Input",
+ CellID->1025428144],
+Cell[10705, 389, 400, 9, 42, "Output",
+ CellID->940365462]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[11142, 403, 379, 10, 20, "Input",
+ CellID->1688284977],
+Cell[11524, 415, 6411, 162, 55, "Output",
+ CellID->1808823346]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[17984, 583, 100, 2, 42, "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+Cell[18087, 587, 125, 3, 25, "ExampleSection",
+ CellID->1293636265],
+Cell[18215, 592, 148, 3, 17, "ExampleSection",
+ CellID->1020263627],
+Cell[CellGroupData[{
+Cell[18388, 599, 127, 3, 17, "ExampleSection",
+ CellID->2061341341],
+Cell[18518, 604, 130, 3, 70, "ExampleSubsection",
+ CellID->1757724783],
+Cell[18651, 609, 130, 3, 70, "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+Cell[18796, 615, 131, 3, 17, "ExampleSection",
+ CellID->258228157],
+Cell[18930, 620, 142, 3, 17, "ExampleSection",
+ CellID->2123667759],
+Cell[19075, 625, 135, 3, 17, "ExampleSection",
+ CellID->1305812373],
+Cell[19213, 630, 140, 3, 17, "ExampleSection",
+ CellID->1653164318],
+Cell[19356, 635, 132, 3, 17, "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+}
+]
+*)
+

--- a/FeynCalc/DocSource/English/ReferencePages/Symbols/FCLoopPropagatorsToLineMomenta.nb
+++ b/FeynCalc/DocSource/English/ReferencePages/Symbols/FCLoopPropagatorsToLineMomenta.nb
@@ -1,0 +1,586 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 10.4' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     15062,        576]
+NotebookOptionsPosition[     10730,        421]
+NotebookOutlinePosition[     11343,        445]
+CellTagsIndexPosition[     11264,        440]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[TextData[{
+ "New in: ",
+ Cell["9.3", "HistoryData",
+  CellTags->"New"],
+ " | Modified in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Modified"],
+ " | Obsolete in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Obsolete"],
+ " | Excised in: ",
+ Cell[" ", "HistoryData",
+  CellTags->"Excised"]
+}], "History",
+ CellID->1247902091],
+
+Cell[CellGroupData[{
+
+Cell["Categorization", "CategorizationSection",
+ CellID->1122911449],
+
+Cell["Symbol", "Categorization",
+ CellLabel->"Entity Type",
+ CellID->686433507],
+
+Cell["FeynCalc", "Categorization",
+ CellLabel->"Paclet Name",
+ CellID->605800465],
+
+Cell["FeynCalc`", "Categorization",
+ CellLabel->"Context",
+ CellID->468444828],
+
+Cell["FeynCalc/ref/FCLoopPropagatorsToLineMomenta", "Categorization",
+ CellLabel->"URI"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Keywords", "KeywordsSection",
+ CellID->477174294],
+
+Cell["XXXX", "Keywords",
+ CellID->1164421360]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Syntax Templates", "TemplatesSection",
+ CellID->1872225408],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Additional Function Template",
+ CellID->1562036412],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Arguments Pattern",
+ CellID->158391909],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Local Variables",
+ CellID->1360575930],
+
+Cell[BoxData[""], "Template",
+ CellLabel->"Color Equal Signs",
+ CellID->793782254]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Details", "DetailsSection",
+ CellID->307771771],
+
+Cell["XXXX", "Details",
+ CellLabel->"Lead",
+ CellID->670882175],
+
+Cell["XXXX", "Details",
+ CellLabel->"Developers",
+ CellID->350963985],
+
+Cell["XXXX", "Details",
+ CellLabel->"Authors",
+ CellID->8391405],
+
+Cell["XXXX", "Details",
+ CellLabel->"Feature Name",
+ CellID->3610269],
+
+Cell["XXXX", "Details",
+ CellLabel->"QA",
+ CellID->401364205],
+
+Cell["XXXX", "Details",
+ CellLabel->"DA",
+ CellID->350204745],
+
+Cell["XXXX", "Details",
+ CellLabel->"Docs",
+ CellID->732958810],
+
+Cell["XXXX", "Details",
+ CellLabel->"Features Page Notes",
+ CellID->222905350],
+
+Cell["XXXX", "Details",
+ CellLabel->"Comments",
+ CellID->240026365]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["FCLoopPropagatorsToLineMomenta", "ObjectName",
+ CellID->1224892054],
+
+Cell[TextData[{
+ Cell["   ", "ModInfo"],
+ Cell[BoxData[
+  RowBox[{"FCLoopPropagatorsToLineMomenta", "[", 
+   RowBox[{"{", 
+    RowBox[{"prop1", ",", "prop2", ",", "..."}], "}"}], "]"}]], 
+  "InlineFormula"],
+ " \[LineSeparator] is an auxiliary function that extracts line momenta \
+flowing through the given list of propagators."
+}], "Usage",
+ CellChangeTimes->{{3.82427438941116*^9, 3.824274398035228*^9}},
+ CellID->982511436],
+
+Cell["XXXX", "Notes",
+ CellID->1067943069]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Tutorials", "TutorialsSection",
+ CellID->250839057],
+
+Cell["XXXX", "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Demonstrations", "RelatedDemonstrationsSection",
+ CellID->1268215905],
+
+Cell["XXXX", "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Related Links", "RelatedLinksSection",
+ CellID->1584193535],
+
+Cell["XXXX", "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["See Also", "SeeAlsoSection",
+ CellID->1255426704],
+
+Cell["XXXX", "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More About", "MoreAboutSection",
+ CellID->38303248],
+
+Cell["XXXX", "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[GridBox[{
+    {
+     StyleBox["Examples", "PrimaryExamplesSection"], 
+     ButtonBox[
+      RowBox[{
+       RowBox[{"More", " ", "Examples"}], " ", "\[RightTriangle]"}],
+      BaseStyle->"ExtendedExamplesLink",
+      ButtonData:>"ExtendedExamples"]}
+   }],
+  $Line = 0; Null]], "PrimaryExamplesSection",
+ CellID->880084151],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"FCLoopPropagatorsToLineMomenta", "[", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"SFAD", "[", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"q", "+", "l"}], ",", 
+        RowBox[{"m", "^", "2"}]}], "}"}], "]"}], ",", 
+     RowBox[{"SFAD", "[", 
+      RowBox[{"{", 
+       RowBox[{"p", ",", 
+        RowBox[{"-", 
+         RowBox[{"m", "^", "2"}]}]}], "}"}], "]"}]}], "}"}], ",", 
+   RowBox[{"FCE", "\[Rule]", "True"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.824274433592214*^9, 3.824274443528899*^9}},
+ CellLabel->"In[10]:=",
+ CellID->1940347290],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"(", "\[NoBreak]", GridBox[{
+     {
+      RowBox[{"l", "+", "q"}], "p"},
+     {
+      RowBox[{"-", 
+       SuperscriptBox["m", "2"]}], 
+      SuperscriptBox["m", "2"]},
+     {
+      FormBox[
+       FractionBox["1", 
+        TemplateBox[{"\"(\"",RowBox[{
+            SuperscriptBox[
+             RowBox[{
+               FormBox["\"(\"", TraditionalForm], 
+               FormBox[
+                FormBox[
+                 RowBox[{
+                   FormBox["l", TraditionalForm], "+", 
+                   FormBox["q", TraditionalForm]}], TraditionalForm], 
+                TraditionalForm], 
+               FormBox["\")\"", TraditionalForm]}], 2]}],RowBox[{"-", 
+            SuperscriptBox["m", "2"]}],"\"+\"",
+          RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+         "RowDefault"]],
+       TraditionalForm], 
+      FormBox[
+       FractionBox["1", 
+        TemplateBox[{"\"(\"",SuperscriptBox[
+           FormBox[
+            FormBox["p", TraditionalForm], TraditionalForm], 2],"\"+\"",
+          SuperscriptBox["m", "2"],"\"+\"",
+          RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+         "RowDefault"]],
+       TraditionalForm]}
+    },
+    GridBoxAlignment->{
+     "Columns" -> {{Center}}, "ColumnsIndexed" -> {}, "Rows" -> {{Baseline}}, 
+      "RowsIndexed" -> {}},
+    GridBoxSpacings->{"Columns" -> {
+        Offset[0.27999999999999997`], {
+         Offset[0.7]}, 
+        Offset[0.27999999999999997`]}, "ColumnsIndexed" -> {}, "Rows" -> {
+        Offset[0.2], {
+         Offset[0.4]}, 
+        Offset[0.2]}, "RowsIndexed" -> {}}], "\[NoBreak]", ")"}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{{3.824274437445698*^9, 3.824274444156776*^9}},
+ CellLabel->"Out[10]=",
+ CellID->580176418]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"FCLoopPropagatorsToLineMomenta", "[", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"CFAD", "[", 
+     RowBox[{"{", 
+      RowBox[{
+       RowBox[{"{", 
+        RowBox[{"0", ",", 
+         RowBox[{"2", 
+          RowBox[{"v", ".", 
+           RowBox[{"(", 
+            RowBox[{"q", "+", "r"}], ")"}]}]}]}], "}"}], ",", 
+       RowBox[{"m", "^", "2"}]}], "}"}], "]"}], "}"}], ",", 
+   RowBox[{"FCE", "\[Rule]", "True"}], ",", 
+   RowBox[{"AuxiliaryMomenta", "\[Rule]", 
+    RowBox[{"{", "v", "}"}]}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.824274457591066*^9, 3.8242744575919724`*^9}},
+ CellLabel->"In[11]:=",
+ CellID->1157096663],
+
+Cell[BoxData[
+ FormBox[
+  RowBox[{"(", "\[NoBreak]", GridBox[{
+     {
+      RowBox[{"q", "+", "r"}]},
+     {
+      SuperscriptBox["m", "2"]},
+     {
+      FormBox[
+       FractionBox["1", 
+        TemplateBox[{"\"(\"",RowBox[{"2", " ", 
+            RowBox[{"(", 
+              RowBox[{
+                FormBox["\"(\"", TraditionalForm], 
+                FormBox[
+                 FormBox[
+                  RowBox[{
+                    FormBox[
+                    StyleBox["q", Bold, StripOnInput -> False], 
+                    TraditionalForm], "+", 
+                    FormBox[
+                    StyleBox["r", Bold, StripOnInput -> False], 
+                    TraditionalForm]}], TraditionalForm], TraditionalForm], 
+                FormBox["\")\"", TraditionalForm], 
+                FormBox["\"\[CenterDot]\"", TraditionalForm], 
+                FormBox[
+                 FormBox[
+                  StyleBox["v", Bold, StripOnInput -> False], 
+                  TraditionalForm], TraditionalForm]}], ")"}]}],"\"+\"",
+          SuperscriptBox["m", "2"],"\"-\"",
+          RowBox[{"\[ImaginaryI]", " ", "\"\[Eta]\""}],"\")\""},
+         "RowDefault"]],
+       TraditionalForm]}
+    },
+    GridBoxAlignment->{
+     "Columns" -> {{Center}}, "ColumnsIndexed" -> {}, "Rows" -> {{Baseline}}, 
+      "RowsIndexed" -> {}},
+    GridBoxSpacings->{"Columns" -> {
+        Offset[0.27999999999999997`], {
+         Offset[0.7]}, 
+        Offset[0.27999999999999997`]}, "ColumnsIndexed" -> {}, "Rows" -> {
+        Offset[0.2], {
+         Offset[0.4]}, 
+        Offset[0.2]}, "RowsIndexed" -> {}}], "\[NoBreak]", ")"}], 
+  TraditionalForm]], "Output",
+ CellChangeTimes->{3.824274459023131*^9},
+ CellLabel->"Out[11]=",
+ CellID->2058588956]
+}, Open  ]]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["More Examples", "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Scope", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1293636265],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Generalizations & Extensions", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1020263627],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ InterpretationBox[Cell["Options", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2061341341],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1757724783],
+
+Cell[BoxData[
+ InterpretationBox[Cell["XXXX", "ExampleSubsection"],
+  $Line = 0; Null]], "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Applications", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->258228157],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Properties & Relations", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->2123667759],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Possible Issues", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1305812373],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Interactive Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->1653164318],
+
+Cell[BoxData[
+ InterpretationBox[Cell["Neat Examples", "ExampleSection"],
+  $Line = 0; Null]], "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+},
+WindowSize->{700, 770},
+WindowMargins->{{2744, Automatic}, {Automatic, 147}},
+CellContext->"Global`",
+FrontEndVersion->"10.4 for Linux x86 (64-bit) (April 11, 2016)",
+StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStyles.nb", 
+  CharacterEncoding -> "UTF-8"]
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "ExtendedExamples"->{
+  Cell[9210, 363, 100, 2, 42, "ExtendedExamplesSection",
+   CellTags->"ExtendedExamples",
+   CellID->1854448968]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"ExtendedExamples", 11126, 433}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 325, 14, 19, "History",
+ CellID->1247902091],
+Cell[CellGroupData[{
+Cell[908, 38, 68, 1, 22, "CategorizationSection",
+ CellID->1122911449],
+Cell[979, 41, 79, 2, 70, "Categorization",
+ CellID->686433507],
+Cell[1061, 45, 81, 2, 70, "Categorization",
+ CellID->605800465],
+Cell[1145, 49, 78, 2, 70, "Categorization",
+ CellID->468444828],
+Cell[1226, 53, 88, 1, 70, "Categorization"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1351, 59, 55, 1, 15, "KeywordsSection",
+ CellID->477174294],
+Cell[1409, 62, 45, 1, 70, "Keywords",
+ CellID->1164421360]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1491, 68, 65, 1, 15, "TemplatesSection",
+ CellID->1872225408],
+Cell[1559, 71, 94, 2, 70, "Template",
+ CellID->1562036412],
+Cell[1656, 75, 82, 2, 70, "Template",
+ CellID->158391909],
+Cell[1741, 79, 81, 2, 70, "Template",
+ CellID->1360575930],
+Cell[1825, 83, 82, 2, 70, "Template",
+ CellID->793782254]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[1944, 90, 53, 1, 15, "DetailsSection",
+ CellID->307771771],
+Cell[2000, 93, 63, 2, 70, "Details",
+ CellID->670882175],
+Cell[2066, 97, 69, 2, 70, "Details",
+ CellID->350963985],
+Cell[2138, 101, 64, 2, 70, "Details",
+ CellID->8391405],
+Cell[2205, 105, 69, 2, 70, "Details",
+ CellID->3610269],
+Cell[2277, 109, 61, 2, 70, "Details",
+ CellID->401364205],
+Cell[2341, 113, 61, 2, 70, "Details",
+ CellID->350204745],
+Cell[2405, 117, 63, 2, 70, "Details",
+ CellID->732958810],
+Cell[2471, 121, 78, 2, 70, "Details",
+ CellID->222905350],
+Cell[2552, 125, 67, 2, 70, "Details",
+ CellID->240026365]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[2656, 132, 73, 1, 48, "ObjectName",
+ CellID->1224892054],
+Cell[2732, 135, 427, 11, 69, "Usage",
+ CellID->982511436],
+Cell[3162, 148, 42, 1, 19, "Notes",
+ CellID->1067943069]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3241, 154, 57, 1, 35, "TutorialsSection",
+ CellID->250839057],
+Cell[3301, 157, 45, 1, 15, "Tutorials",
+ CellID->341631938]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3383, 163, 83, 1, 25, "RelatedDemonstrationsSection",
+ CellID->1268215905],
+Cell[3469, 166, 58, 1, 15, "RelatedDemonstrations",
+ CellID->1129518860]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3564, 172, 65, 1, 25, "RelatedLinksSection",
+ CellID->1584193535],
+Cell[3632, 175, 49, 1, 15, "RelatedLinks",
+ CellID->1038487239]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3718, 181, 55, 1, 25, "SeeAlsoSection",
+ CellID->1255426704],
+Cell[3776, 184, 43, 1, 15, "SeeAlso",
+ CellID->929782353]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3856, 190, 57, 1, 25, "MoreAboutSection",
+ CellID->38303248],
+Cell[3916, 193, 46, 1, 15, "MoreAbout",
+ CellID->1665078683]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3999, 199, 356, 11, 53, "PrimaryExamplesSection",
+ CellID->880084151],
+Cell[CellGroupData[{
+Cell[4380, 214, 591, 18, 34, "Input",
+ CellID->1940347290],
+Cell[4974, 234, 1766, 50, 64, "Output",
+ CellID->580176418]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[6777, 289, 650, 19, 34, "Input",
+ CellID->1157096663],
+Cell[7430, 310, 1731, 47, 64, "Output",
+ CellID->2058588956]
+}, Open  ]]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[9210, 363, 100, 2, 42, "ExtendedExamplesSection",
+ CellTags->"ExtendedExamples",
+ CellID->1854448968],
+Cell[9313, 367, 125, 3, 25, "ExampleSection",
+ CellID->1293636265],
+Cell[9441, 372, 148, 3, 17, "ExampleSection",
+ CellID->1020263627],
+Cell[CellGroupData[{
+Cell[9614, 379, 127, 3, 17, "ExampleSection",
+ CellID->2061341341],
+Cell[9744, 384, 130, 3, 70, "ExampleSubsection",
+ CellID->1757724783],
+Cell[9877, 389, 130, 3, 70, "ExampleSubsection",
+ CellID->1295379749]
+}, Closed]],
+Cell[10022, 395, 131, 3, 17, "ExampleSection",
+ CellID->258228157],
+Cell[10156, 400, 142, 3, 17, "ExampleSection",
+ CellID->2123667759],
+Cell[10301, 405, 135, 3, 17, "ExampleSection",
+ CellID->1305812373],
+Cell[10439, 410, 140, 3, 17, "ExampleSection",
+ CellID->1653164318],
+Cell[10582, 415, 132, 3, 17, "ExampleSection",
+ CellID->589267740]
+}, Open  ]]
+}
+]
+*)
+
+(* End of internal cache information *)
+

--- a/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
+++ b/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
@@ -49,7 +49,7 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 	Block[{	ex, props, allmoms, extmoms, lineMomenta, null1, null2,
 			intEdgesList, extEdgesList, numExtMoms,	numEdges, lmoms, optFactoring,
 			auxExtEdgesList, numIntVertices, numExtVertices, auxExternalMoms,
-			numVertices, res},
+			numVertices, res, uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank},
 
 		If [OptionValue[FCVerbose]===False,
 			lbtgVerbose=$VeryVerbose,
@@ -68,7 +68,7 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 			ex = FCI[expr]
 		];
 
-		If [!FreeQ2[$ScalarProducts, {lmoms}],
+		If [!FreeQ2[$ScalarProducts, {lmomsRaw}],
 			Message[FCLoopBasisIntegralToGraph::failmsg, "Some of the loop momenta have scalar product rules attached to them."];
 			Abort[]
 		];
@@ -94,6 +94,14 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 
 		(*	All momenta that are not listed as loop momenta will be treated as external momenta.*)
 		extmoms = Complement[allmoms, lmoms];
+
+		{uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank} =
+			FCFeynmanPrepare[ex, lmoms, FCI -> True, Check->False, Collecting -> False];
+
+		If[	FreeQ2[ExpandScalarProduct[fPoly,FCI->True],{Momentum,CartesianMomentum,TemporalMomentum}],
+			(*tadpole!*)
+			extmoms={}
+		];
 
 
 		FCPrint[1, "FCLoopBasisIntegralToGraph: Loop momenta: ", lmoms, FCDoControl->lbtgVerbose];

--- a/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
+++ b/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
@@ -49,7 +49,7 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 	Block[{	ex, props, allmoms, extmoms, lineMomenta, null1, null2,
 			intEdgesList, extEdgesList, numExtMoms,	numEdges, lmoms, optFactoring,
 			auxExtEdgesList, numIntVertices, numExtVertices, auxExternalMoms,
-			numVertices, res, uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank},
+			numVertices, res, uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank, dots},
 
 		If [OptionValue[FCVerbose]===False,
 			lbtgVerbose=$VeryVerbose,
@@ -109,9 +109,13 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 
 
 		props = FCLoopBasisIntegralToPropagators[ex, lmoms, FCI->True, Tally->True];
-		props = props /. {a_FeynAmpDenominator, i_Integer} /; i > 1 :> Sequence @@ Table[{a, 1}, {j, 1, i}];
 
+		FCPrint[3, "FCLoopBasisIntegralToGraph: After FCLoopBasisIntegralToPropagators: ", props, FCDoControl->lbtgVerbose];
+
+
+		dots  = Transpose[props][[2]];
 		props = Transpose[props][[1]];
+
 		(*	TODO add Cartesian propagators *)
 		props = FeynAmpDenominatorExplicit[1/props, ExpandScalarProduct -> False, FCE -> True] // ReplaceAll[#, SPD[a_, a_] :> a] &;
 
@@ -187,7 +191,7 @@ FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 		res = makeGraph[res];
 
 		res = res /. {
-			Labeled[a_,i_Integer?Positive] :> Labeled[a, Extract[props,{i}]],
+			Labeled[a_,i_Integer?Positive] :> Labeled[a, {Extract[props,{i}], Extract[dots,{i}]}],
 
 			Labeled[a_,i_Integer?Negative] :> Labeled[a, Extract[Join[auxExtEdgesList,extEdgesList],{i}][[2]]]
 		};

--- a/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
+++ b/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
@@ -1,0 +1,650 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: FCLoopBasis														*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:	Information about the propagators of the given multi-loop
+				integral													*)
+
+(* ------------------------------------------------------------------------ *)
+
+FCLoopBasisIntegralToGraph::usage=
+"FCLoopBasisIntegralToPropagators[int, {q1,q2,...}] returns a list of edge rules that represent the loop integral \
+int. "
+
+FCLoopBasisIntegralToGraph::failmsg =
+"Error! FCLoopBasisIntegralToGraph encountered a fatal problem and must abort the computation. \
+The problem reads: `1`";
+
+Begin["`Package`"]
+End[]
+
+Begin["`FCLoopBasisIntegralToGraph`Private`"]
+
+factorizingIntegral::usage="";
+optSelect::usage="";
+lbtgVerbose::usage="";
+mark::usage="";
+maxVertexDegree::usage="";
+
+Options[FCLoopBasisIntegralToGraph] = {
+	FCE 				-> False,
+	FCI 				-> False,
+	FCVerbose 			-> False,
+	VertexDegree		-> 6,
+	Select				-> 1,
+	Factoring			-> Auto
+};
+
+
+FCLoopBasisIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
+	Block[{	ex, props, allmoms, extmoms, lineMomenta, null1, null2,
+			intEdgesList, extEdgesList, numExtMoms,	numEdges, lmoms, optFactoring,
+			auxExtEdgesList, numIntVertices, numExtVertices, auxExternalMoms,
+			numVertices, res},
+
+		If [OptionValue[FCVerbose]===False,
+			lbtgVerbose=$VeryVerbose,
+			If[MatchQ[OptionValue[FCVerbose], _Integer],
+				lbtgVerbose=OptionValue[FCVerbose]
+			];
+		];
+
+		maxVertexDegree = OptionValue[VertexDegree];
+
+		optFactoring = OptionValue[Factoring];
+		optSelect = OptionValue[Select];
+
+		If[OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		If [!FreeQ2[$ScalarProducts, {lmoms}],
+			Message[FCLoopBasisIntegralToGraph::failmsg, "Some of the loop momenta have scalar product rules attached to them."];
+			Abort[]
+		];
+
+		If[	!MatchQ[ex,{__}|_. _FeynAmpDenominator],
+			Message[FCLoopBasisIntegralToGraph::failmsg, "The input expression is not a proper integral or list of propagators"];
+			Abort[]
+		];
+
+		FCPrint[1,"FCLoopBasisIntegralToGraph: Entering. ", FCDoControl->lbtgVerbose];
+		FCPrint[3,"FCLoopBasisIntegralToGraph: Entering  with: ", ex, FCDoControl->lbtgVerbose];
+
+		(*	List of all momenta that appear inside the integral*)
+		allmoms =
+			Cases[MomentumExpand[ex, FCI->True],	(Momentum | CartesianMomentum | TemporalMomentum)[x_, ___] :> x, Infinity] //
+			Sort // DeleteDuplicates;
+
+		(*
+			If the user specifies loop momenta that are not present in the integral, we can simply ignore those.
+			This is useful when processing large sets of topologies that contain different number of loops.
+		*)
+		lmoms = Intersection[allmoms,lmomsRaw];
+
+		(*	All momenta that are not listed as loop momenta will be treated as external momenta.*)
+		extmoms = Complement[allmoms, lmoms];
+
+
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Loop momenta: ", lmoms, FCDoControl->lbtgVerbose];
+		FCPrint[1, "FCLoopBasisIntegralToGraph: External momenta: ", extmoms, FCDoControl->lbtgVerbose];
+
+
+		props = FCLoopBasisIntegralToPropagators[ex, lmoms, FCI->True, Tally->True];
+		props = props /. {a_FeynAmpDenominator, i_Integer} /; i > 1 :> Sequence @@ Table[{a, 1}, {j, 1, i}];
+
+		props = Transpose[props][[1]];
+		(*	TODO add Cartesian propagators *)
+		props = FeynAmpDenominatorExplicit[1/props, ExpandScalarProduct -> False, FCE -> True] // ReplaceAll[#, SPD[a_, a_] :> a] &;
+
+		(*	Extract momenta flowing through inverse propagators, i.e. [(p-q)^2 - m^2] -> p-q *)
+		(*	TODO Suport SCET propagators *)
+
+		lineMomenta = (SelectNotFree2[(# + null1 + null2), allmoms] & /@ props) /. null1 | null2 -> 0;
+
+		numEdges = Length[lineMomenta];
+		intEdgesList = Transpose[{Range[numEdges], lineMomenta}];
+		numExtMoms = Length[extmoms];
+		extEdgesList = Transpose[{-Range[numExtMoms], extmoms}];
+
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Number of edges: ", numEdges, FCDoControl->lbtgVerbose];
+
+
+		(*
+			We need to enumerate the occurring momenta for the reconstruction of vertices
+			However, as far as the external momenta are concerned, there is an additional momentum
+			which is a linear combination of the known ones.
+
+			For example, a box integral has only 3 external momenta q1,q2 and q3 but 4 legs. However,
+			as we do not enforce all momenta to be incoming, the momentum on the 4th legs can be
+			q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So we build all possible linear combinations and reconstruct
+			the corresponding vertex at the very end when all other vertices are known to avoid misreconstruction.
+		*)
+		numVertices = 1 + numEdges - Length[lmoms];
+		numExtVertices =  (numExtMoms+1);
+		numIntVertices = numVertices - numExtVertices;
+
+		If[numExtMoms=!=0,
+			If[	numExtMoms>1,
+					auxExternalMoms = Map[Total[Thread[Times[extmoms, #]]] &, generateSigns[numExtMoms+1]];
+					auxExtEdgesList = Transpose[{-Range[numExtMoms+1,numExtMoms+Length[auxExternalMoms]], auxExternalMoms}];
+					,
+					auxExtEdgesList = {{-2, extmoms[[1]]}, {-3, -extmoms[[1]]}}
+			];
+			FCPrint[2, "FCLoopBasisIntegralToGraph: auxExtEdgesList: ", auxExtEdgesList, FCDoControl->lbtgVerbose],
+			auxExtEdgesList = {}
+		];
+
+
+
+
+		(*	We start by reconstructing all internal vertices, i.e. those that are not connected to an external line	*)
+
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Number of internal vertices: ", numIntVertices, FCDoControl->lbtgVerbose];
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Number of external vertices: ", numExtVertices, FCDoControl->lbtgVerbose];
+
+		Which[
+			optFactoring === True || optFactoring === False,
+
+				factorizingIntegral = optFactoring;
+				res = reconstructAllVertices[intEdgesList,extEdgesList,auxExtEdgesList,numIntVertices,numExtVertices],
+			optFactoring === Auto,
+				factorizingIntegral = False;
+				res = reconstructAllVertices[intEdgesList,extEdgesList,auxExtEdgesList,numIntVertices,numExtVertices];
+				If[	res===False,
+					factorizingIntegral = True;
+					res = reconstructAllVertices[intEdgesList,extEdgesList,auxExtEdgesList,numIntVertices,numExtVertices];
+				],
+			True,
+			Message[FCLoopBasisIntegralToGraph::failmsg, "Unknown value of the option Factoring. Only True, False or Auto are valid values."];
+			Abort[]
+
+		];
+
+		If[	res === False,
+			Message[FCLoopBasisIntegralToGraph::failmsg, "Failed to reconstruct the graph of the given loop integral."];
+			Abort[]
+		];
+
+		res = makeGraph[res];
+
+		res = res /. {
+			Labeled[a_,i_Integer?Positive] :> Labeled[a, Extract[props,{i}]],
+
+			Labeled[a_,i_Integer?Negative] :> Labeled[a, Extract[Join[auxExtEdgesList,extEdgesList],{i}][[2]]]
+		};
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		res
+
+	];
+
+
+
+
+
+
+reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,numIntVertices_Integer,numExtVertices_Integer]:=
+	Block[{	fullyConnectedEdges, currentVertexDegree, intVerticesFound, extVerticesFound,
+			relEdgesList, numEdges, signs, candidates, numExtMoms, intVertexCandidateSets,
+			verticesRaw, fullyConnectedEdgesTest, auxExternalMoms, allVertices, verts,
+			rawInt, rawExt, tmp, lastExtEdge, lastExtVertex} ,
+
+
+
+		fullyConnectedEdges 	= {};
+		intVerticesFound 		= {};
+		extVerticesFound 		= {};
+		intVertexCandidateSets	= {};
+		verticesRaw				= {};
+		fullyConnectedEdgesTest	= {};
+		auxExternalMoms			= {};
+		relEdgesList 			= intEdgesList;
+		numEdges 				= Length[intEdgesList];
+		numExtMoms 				= Length[extEdgesList];
+
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Reconstructing internal vertices.",  FCDoControl->lbtgVerbose];
+		FCPrint[1, "FCLoopBasisIntegralToGraph: Internal edges: ", intEdgesList, FCDoControl->lbtgVerbose];
+
+		currentVertexDegree = 3;
+
+		While[(Length[fullyConnectedEdges]<numEdges) && (currentVertexDegree <= maxVertexDegree)  && Length[intVerticesFound] <= numIntVertices,
+
+			FCPrint[3, "FCLoopBasisIntegralToGraph: Searching for internal vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
+
+			signs = generateSigns[currentVertexDegree];
+			candidates = generateCandidates[If[factorizingIntegral,
+												Join[intEdgesList,intEdgesList],
+												intEdgesList
+											], currentVertexDegree];
+			If[candidates==={}, Break[]];
+			intVerticesFound = Join[intVerticesFound,findInternalVertices[intEdgesList, candidates, signs]];
+			fullyConnectedEdges = Cases[Tally[Flatten[intVerticesFound]], {i_Integer?Positive, 2} :> i]//Union;
+			FCPrint[3, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+			currentVertexDegree++;
+		];
+
+		If[	Length[intVerticesFound]<numIntVertices,
+			(*
+				In the case of a tadpole it may happen that we can reconstruct all vertices already at this stage,
+				since there are no external vertices
+			*)
+			If[ !(numExtMoms===0 && (Length[intVerticesFound]===(numIntVertices+1))),
+				(*Message[FCLoopBasisIntegralToGraph::failmsg, "Failed to reconstruct all internal vertices"];*)
+				Return[False]
+			]
+		];
+
+		(* It is also possible that we reconstruct some fake vertices *)
+
+		FCPrint[2, "FCLoopBasisIntegralToGraph: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
+		If[	Length[intVerticesFound] >= numIntVertices,
+			If[	numExtMoms=!=0,
+				intVertexCandidateSets = Subsets[intVerticesFound, {numIntVertices}];
+				(*fullyConnectedEdges = Cases[Tally[Flatten[intVerticesFound]], {i_Integer?Positive, 2} :> i]//Union;*)
+			];
+			FCPrint[2, "Vertex candidate sets: ", intVertexCandidateSets, FCDoControl->lbtgVerbose]
+		];
+
+
+
+
+		FCPrint[2, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+
+		(*	Now we only need to reconstruct the external vertices. However, there are some special cases to take care of!	*)
+
+		If[	numExtMoms=!=0,
+
+
+			FCPrint[1, "FCLoopBasisIntegralToGraph: Reconstructing external vertices (stage I).", FCDoControl->lbtgVerbose];
+
+			(* Let us start by picking the vertices that are connected to the momenta that explicitly appear in the propagators *)
+			verticesRaw = Map[
+			(
+			(*Print["here:", #];*)
+			currentVertexDegree = 3;
+			extVerticesFound = {};
+			fullyConnectedEdges = Cases[Tally[Flatten[{#}]], {i_Integer?Positive, 2} :> i]//Union;
+			relEdgesList = intEdgesList;
+			While[(currentVertexDegree <= maxVertexDegree),
+
+			FCPrint[3, "FCLoopBasisIntegralToGraph: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
+
+			signs = generateSigns[currentVertexDegree];
+			candidates = generateCandidates[If[factorizingIntegral,
+												Join[relEdgesList,relEdgesList],
+												relEdgesList
+											], currentVertexDegree];
+			(*
+			Print["here3:", candidates];
+			Print["here4:", signs];
+			*)
+			If[candidates==={}, Break[]];
+			extVerticesFound = Join[extVerticesFound,findExternalVertices[extEdgesList, candidates, signs]];
+			fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+			FCPrint[3, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+			currentVertexDegree++;
+
+			];
+
+
+			If[	numExtVertices===Length[extVerticesFound] && numExtMoms===1,
+				(*In the case of a 2-point function we can recontstruct both vertices in one run, but this is not desirable here*)
+				extVerticesFound = extVerticesFound[[1;;1]];
+				fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+			];
+
+
+			{#,extVerticesFound} )&, intVertexCandidateSets];
+
+
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Possible vertex candidates: ", verticesRaw, FCDoControl->lbtgVerbose];
+			(*
+				It may happen that we find multiple candidates for a particular external vertex within one set.
+			*)
+
+			verticesRaw = Map[Function[x,
+
+				If[Length[x[[2]]] >= numExtVertices-1,
+
+					First[Map[{x[[1]], #} &,
+				Subsets[x[[2]], {numExtVertices-1}]]
+				],
+				x
+			]
+
+
+			], verticesRaw];
+
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Possible vertex candidates after REV I: ", verticesRaw, FCDoControl->lbtgVerbose];
+
+			verticesRaw = Select[verticesRaw, ((Length[#[[1]]] === numIntVertices) && (Length[#[[2]]] === numExtVertices - 1))&];
+
+			If[	Length[verticesRaw]===0,
+
+				(*Message[FCLoopBasisIntegralToGraph::failmsg, "Failed to reconstruct all but one external vertices"];*)
+				Return[False]
+			];
+
+
+			(*
+				As far as the external momenta are concerned, there is an additional momentum
+				which is a linear combination of the known ones.
+
+				For example, a box integral has only 3 external momenta q1,q2 and q3 but 4 legs. However,
+				as we do not enforce all momenta to be incoming, the momentum on the 4th legs can be
+				q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So we build all possible linear combinations and reconstruct
+				the corresponding vertex at the very end when all other vertices are known. This helps to avoid misreconstruction.
+			*)
+
+			FCPrint[1, "FCLoopBasisIntegralToGraph: Reconstructing external vertices (stage II).", FCDoControl->lbtgVerbose];
+
+
+
+
+
+			verticesRaw = Map[(
+			lastExtEdge = {};
+			currentVertexDegree = 3;
+
+			intVerticesFound = #[[1]];
+			extVerticesFound = #[[2]];
+			fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+
+			relEdgesList = intEdgesList;
+			While[(Length[fullyConnectedEdges]<numEdges) && (currentVertexDegree <= maxVertexDegree) && Length[extVerticesFound] < (numExtVertices),
+
+			FCPrint[3, "FCLoopBasisIntegralToGraph: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
+
+			signs = generateSigns[currentVertexDegree];
+			candidates = generateCandidates[If[factorizingIntegral,
+												Join[relEdgesList,relEdgesList],
+												relEdgesList
+											], currentVertexDegree];
+			If[candidates==={}, Break[]];
+			(*Print["candidates: ", candidates];*)
+			lastExtVertex = findExternalVertices[auxExtEdgesList, candidates, signs];
+			(*Print[lastExtVertex];*)
+			If[	lastExtVertex=!={},
+
+				(*Print["Bingo!"];
+				Print[lastExtVertex];*)
+				lastExtVertex = lastExtVertex[[1;;1]];
+
+				(*Print[lastExtVertex];*)
+				lastExtEdge = Select[auxExtEdgesList,!FreeQ2[#[[1]],lastExtVertex[[1]]]&];
+				(*Print[lastExtEdge];*)
+				fullyConnectedEdgesTest = Cases[Tally[Flatten[{#[[1]],Join[#[[2]],lastExtVertex]}]], {i_Integer?Positive, 2} :> i]//Union;
+				(*Print[fullyConnectedEdgesTest];*)
+				If[	fullyConnectedEdgesTest===Range[numEdges],
+					Break[]
+				]
+			];
+
+			(*extVerticesFound = Join[extVerticesFound,findExternalVertices[auxExtEdgesList, candidates, signs]];*)
+			(*FCPrint[3, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];*)
+			currentVertexDegree++;
+
+			];
+
+			If[	fullyConnectedEdgesTest===Range[numEdges],
+				{#[[1]],#[[2]],lastExtVertex,lastExtEdge},
+				Unevaluated[Sequence[]]
+			]
+
+			)&, verticesRaw];
+
+
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Possible vertex candidates: REV II", verticesRaw, FCDoControl->lbtgVerbose];
+
+			If[	Length[verticesRaw]===0,
+				(*Message[FCLoopBasisIntegralToGraph::failmsg, "Failed to connect all occurring edges to vertices."];*)
+				Return[False]
+			];
+
+			If[	Length[verticesRaw]>1,
+				Null
+				(*Message[FCLoopBasisIntegralToGraph::failmsg, "Ambiguities in the final vertex reconstruction."];*)
+				(*Abort[]*)
+
+			];
+			(*TODO Check isomorphy?*)
+			verticesRaw= verticesRaw[[optSelect]];
+
+			lastExtEdge = verticesRaw[[4]];
+			intVerticesFound = verticesRaw[[1]];
+			extVerticesFound = Join[verticesRaw[[2]],verticesRaw[[3]]];
+
+
+
+			(*intVerticesFound = verticesRaw[[OptionValue[Select]]][[1]];
+			extVerticesFound = verticesRaw[[OptionValue[Select]]][[2]];*)
+			fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+
+
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+
+
+			(*Print[verticesRaw];
+			Abort[];*)
+
+			,
+
+			(*	We are dealing with a tadpole!	*)
+
+			FCPrint[2, "FCLoopBasisIntegralToGraph: Tadpole integral!", FCDoControl->lbtgVerbose];
+
+			Which[
+
+				(*	Special case: a 2-vertex tadpole *)
+				(fullyConnectedEdges === {}) && (Length[intVerticesFound] === 1) && (numExtVertices === 1),
+					intVerticesFound = Join[intVerticesFound,intVerticesFound];
+					fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union,
+
+				(*	Special case: a 1-vertex tadpole *)
+				(fullyConnectedEdges === {}) && (intVerticesFound === {}) && (numExtVertices === 1),
+					intVerticesFound = { {1,1}};
+					fullyConnectedEdges = {1},
+
+				(*	Generic tadpole *)
+				True,
+				verticesRaw = Subsets[intVerticesFound, {numIntVertices+1}];
+				If[	Length[verticesRaw]>1,
+					Null
+					(*Message[FCLoopBasisIntegralToGraph::failmsg, "Ambiguities in the final vertex reconstruction."];*)
+					(*Abort[]*)
+				];
+				(*TODO Check isomorphy?*)
+				intVerticesFound = verticesRaw[[optSelect]];
+
+				fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union
+			];
+		];
+
+
+		FCPrint[2, "FCLoopBasisIntegralToGraph: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
+		FCPrint[2, "FCLoopBasisIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+
+
+		If[	fullyConnectedEdges=!=Range[numEdges],
+			(*Message[FCLoopBasisIntegralToGraph::failmsg, "Failed to connect all occurring edges to vertices"];*)
+			Return[False]
+		];
+
+
+		allVertices = Join[extVerticesFound, intVerticesFound];
+
+		FCPrint[2, "FCLoopBasisIntegralToGraph: All reconstructed vertices: ", allVertices, FCDoControl->lbtgVerbose];
+
+
+		(*Range introduces labels to the vertices ... *)
+		verts = Transpose[{Range[Length[allVertices]], allVertices}];
+
+		If[numExtMoms=!=0,
+			If[lastExtEdge=!={},
+				rawExt = Map[Select[verts, Function[x, ! FreeQ[x[[2]], #]]] &, Transpose[Join[extEdgesList, lastExtEdge]][[1]]],
+				rawExt = Map[Select[verts, Function[x, ! FreeQ[x[[2]], #]]] &, Transpose[extEdgesList][[1]]];
+			],
+			rawExt = {{}}
+		];
+
+
+		(*Takes care of cases such as FAD[p1] FAD[p3] FAD[p1 + q1] FAD[p3 + q1] FAD[{p2 - p3, m1}] *)
+		rawInt = Map[
+			(
+			tmp = Join[Select[verts, Function[x, ! FreeQ[x[[2]], #]]],{#}];
+			If[Length[tmp]===2,
+				{tmp[[1]],tmp[[1]],tmp[[2]]},
+				tmp
+			]
+
+			)&, Transpose[intEdgesList][[1]]];
+
+
+		(*1-loop tadpole *)
+		If[	(numEdges===1) && (numExtMoms===0) && (Length[allVertices]===1) && (Length[rawInt]===1),
+			rawInt = {{{1, {1, 1}}, {1, {1, 1}},1}}
+		];
+
+		Return[{rawExt, rawInt}];
+
+
+
+
+	];
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+makeGraph[res_] := (If[res[[1]] =!= {{}},
+	Join[Map[Labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &, res[[2]]],
+		Map[Labeled[Rule[#[[2]][[1]], #[[1]]], #[[2]][[1]]] &,
+	First /@ res[[1]]]] //
+	Sort, (Map[Labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &,
+	res[[2]]]) // Sort]);
+
+
+
+
+
+
+
+
+(*TODO: safe for memoization*)
+generateSigns[maxVertexDegree_Integer?Positive]:=
+	DeleteDuplicates[Tuples[{+1, -1}, maxVertexDegree-1], (#1 === -#2) &]/; maxVertexDegree>=3;
+
+
+generateCandidates[intEdgesList_List, maxVertexDegree_Integer?Positive]:=
+	Subsets[intEdgesList, {maxVertexDegree-1}];
+
+
+
+checkRouting[ex_, mom_, signs_List] :=
+	Flatten[Map[sum[Thread[Times[ex, #]], mom] &, signs]];
+
+sum[li_List, mom_] :=
+	SelectNotFree[Total[li] + {mom, -mom}, 0] /. 0 -> mark;
+
+
+
+(*Given a list of candidate edges, find those that are connected to the current edge *)
+connectEdge[{id_Integer, mom_}, candidates_List, signs_List] :=
+	SelectNotFree[Map[{Sort[Join[{id}, Transpose[#][[1]]]],	checkRouting[Transpose[#][[2]], mom, signs]} &, candidates], mark];
+
+
+findInternalVertices[intEdges_List, candidates_List, signs_List] :=
+	Block[{intVertices, aux, res},
+
+		FCPrint[3, "FCLoopBasisIntegralToGraph: findInternalVertices: Entering.", FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findInternalVertices: intEdges: ", intEdges , FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findInternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findInternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
+
+		intVertices = {};
+		Scan[
+			(aux = connectEdge[#, candidates, signs];
+
+			(*	Remove cases where an edge appears in the list more than once	*)
+			aux = aux /. {{___,a_Integer,___,a_Integer,___},mark} -> Unevaluated[Sequence[]];
+			If[aux === {} || MatchQ[aux,{{___,a_Integer,___,a_Integer,___},mark}],
+				(* Notice that this procedure will not find vertices that involve external edges	*)
+				Unevaluated[Sequence[]]
+			];
+			FCPrint[4, "FCLoopBasisIntegralToGraph: findInternalVertices: Current edge: ", #, FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopBasisIntegralToGraph: findInternalVertices: Reconstructed vertices ", aux, FCDoControl->lbtgVerbose];
+			(*TODO: Once we have found all internal vertices, stop the evaluation!!! *)
+
+			(*If[Length[intVertices] >= maxVertices, Throw[intVertices]];*)
+
+			intVertices = Union[Join[intVertices, aux]];
+
+			) &,
+		intEdges
+		];
+		(*];*)
+
+		res = Transpose[intVertices];
+		If[res=!={},
+			res = First[res]
+		];
+		FCPrint[3, "FCLoopBasisIntegralToGraph: findInternalVertices: Leaving with: ", res, FCDoControl->lbtgVerbose];
+		res
+	];
+
+
+findExternalVertices[{}, _List, _List] :=
+	{};
+
+findExternalVertices[extEdges_List,  candidates_List, signs_List] :=
+	Block[{extVertices},
+
+
+		FCPrint[3, "FCLoopBasisIntegralToGraph: findExternalVertices: Entering.", FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findExternalVertices: extEdges: ", extEdges , FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findExternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findExternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
+
+
+		extVertices = Union[Join @@ (connectEdge[#, candidates, signs] & /@ extEdges)];
+
+		FCPrint[4, "FCLoopBasisIntegralToGraph: findExternalVertices: extVertices: ", extVertices , FCDoControl->lbtgVerbose];
+
+		(*TODO More checks*)
+		If[extVertices=!={},
+			Transpose[extVertices][[1]],
+			{}
+		]
+	];
+
+
+FCPrint[1,"FCLoopBasis.m loaded."];
+End[]

--- a/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
+++ b/FeynCalc/LoopIntegrals/FCLoopBasisIntegralToGraph.m
@@ -612,8 +612,13 @@ findInternalVertices[intEdges_List, candidates_List, signs_List] :=
 		];
 		(*];*)
 
-		res = Transpose[intVertices];
+		If[	intVertices=!={},
+			res = Transpose[intVertices],
+			res = {}
+		];
+
 		If[res=!={},
+
 			res = First[res]
 		];
 		FCPrint[3, "FCLoopBasisIntegralToGraph: findInternalVertices: Leaving with: ", res, FCDoControl->lbtgVerbose];

--- a/FeynCalc/LoopIntegrals/FCLoopIntegralToGraph.m
+++ b/FeynCalc/LoopIntegrals/FCLoopIntegralToGraph.m
@@ -16,8 +16,18 @@
 (* ------------------------------------------------------------------------ *)
 
 FCLoopIntegralToGraph::usage=
-"FCLoopBasisIntegralToPropagators[int, {q1,q2,...}] returns a list of edge rules that represent the loop integral \
-int. "
+"FCLoopBasisIntegralToPropagators[int, {q1,q2,...}] constructs a graph \
+representation of the loop integral int that depends on the loop momenta q1, q2, ....\
+The function returns a list of the form {edges,labels,props,pref}, where edges \
+is a list of edge rules representing the loop integral int, labels is a list of
+lists containing the line momentum, multiplicity and the mass term of each propagator, \
+props is a list with the original propagators and pref is the piece of the integral \
+that was ignored when constructing the graph representation (e.g. scalar products or \
+vectors in the numerator) A quick and simple way to plot the graph is to evaluate \
+GraphPlot[Labeled @@@ Transpose[output[[1 ;; 2]]]] or GraphPlot[List @@@ Transpose[output[[1 ;; 2]]]]. \
+The visual quality will not be that great, though. To obtain a nicer plot one might use GraphPlot \
+with a custom EdgeTaggedGraph or export the output to a file and visualize it with an external \
+tool such as dot/neato from graphviz."
 
 FCLoopIntegralToGraph::failmsg =
 "Error! FCLoopIntegralToGraph encountered a fatal problem and must abort the computation. \
@@ -33,25 +43,26 @@ optSelect::usage="";
 lbtgVerbose::usage="";
 mark::usage="";
 maxVertexDegree::usage="";
+labeled::usage="";
 
 Options[FCLoopIntegralToGraph] = {
-	(*n, v and other auxiliary stuff??? *)
-	Except				-> {}
+	AuxiliaryMomenta	-> {},
 	FCE 				-> False,
 	FCI 				-> False,
+	FCProductSplit		-> True,
 	FCVerbose 			-> False,
-	VertexDegree		-> 6,
+	Factoring			-> Auto,
 	Select				-> 1,
-	Factoring			-> Auto
+	VertexDegree		-> 6
 };
 
 (*TODO Ignore scalar products*)
 (*Except: List of propagators to ignore, GFAD, EEC*)
 FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
-	Block[{	ex, props, allmoms, extmoms, lineMomenta, null1, null2,
-			intEdgesList, extEdgesList, numExtMoms,	numEdges, lmoms, optFactoring,
-			auxExtEdgesList, numIntVertices, numExtVertices, auxExternalMoms,
-			numVertices, res, uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank, dots},
+	Block[{	ex, props, allmoms, extmoms, lmoms, lineMomenta, intEdgesList,
+			extEdgesList, numExtMoms,	numEdges, optFactoring,	auxExtEdgesList,
+			numIntVertices, numExtVertices, auxExternalMoms, numVertices,
+			res, aux, dots, optAuxiliaryMomenta, time, pref=1, massTerms},
 
 		If [OptionValue[FCVerbose]===False,
 			lbtgVerbose=$VeryVerbose,
@@ -60,10 +71,10 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 			];
 		];
 
-		maxVertexDegree = OptionValue[VertexDegree];
-
-		optFactoring = OptionValue[Factoring];
-		optSelect = OptionValue[Select];
+		maxVertexDegree 	= OptionValue[VertexDegree];
+		optFactoring 		= OptionValue[Factoring];
+		optSelect 			= OptionValue[Select];
+		optAuxiliaryMomenta = OptionValue[AuxiliaryMomenta];
 
 		If[OptionValue[FCI],
 			ex = expr,
@@ -83,6 +94,17 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 		FCPrint[1,"FCLoopIntegralToGraph: Entering. ", FCDoControl->lbtgVerbose];
 		FCPrint[3,"FCLoopIntegralToGraph: Entering  with: ", ex, FCDoControl->lbtgVerbose];
 
+		(*
+			Normally, when graphing an integral we care only about the denominators. Hence, the numerator should
+			be splitted from the rest. If for some reason, this should not be so, just use the option FCProductSplit->False
+		*)
+		If[	OptionValue[FCProductSplit],
+			{pref,ex} = FCProductSplit[ex, {FeynAmpDenominator}]
+		];
+		FCPrint[1,"FCLoopIntegralToGraph: Prefactor that will be ignored: " ,pref , FCDoControl->lbtgVerbose];
+		FCPrint[1,"FCLoopIntegralToGraph: Part that will be analyzed: ",ex,  FCDoControl->lbtgVerbose];
+
+
 		(*	List of all momenta that appear inside the integral*)
 		allmoms =
 			Cases[MomentumExpand[ex],	(Momentum | CartesianMomentum | TemporalMomentum)[x_, ___] :> x, Infinity] //
@@ -94,61 +116,82 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 		*)
 		lmoms = Intersection[allmoms,lmomsRaw];
 
-		(*	All momenta that are not listed as loop momenta will be treated as external momenta.*)
-		extmoms = Complement[allmoms, lmoms];
+		(*	All momenta that are not listed as loop or auxiliary momenta will be treated as external momenta.*)
+		extmoms = SelectFree[Complement[allmoms, lmoms], optAuxiliaryMomenta];
 
-		{uPoly, fPoly, pows, mat, Q, J, tensorPart, tensorRank} =
-			FCFeynmanPrepare[ex, lmoms, FCI -> True, Check->False, Collecting -> False];
 
-		If[	FreeQ2[ExpandScalarProduct[fPoly,FCI->True],{Momentum,CartesianMomentum,TemporalMomentum}],
+
+
+
+
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Calling FCFeynmanPrepare.", FCDoControl->lbtgVerbose];
+		aux = FCFeynmanPrepare[ex, lmoms, FCI -> True, Check->False, Collecting -> False];
+		FCPrint[1,"FCLoopIntegralToGraph: FCFeynmanPrepare done, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
+
+		(*Check if the F-polynomial corresponds to a tadpole *)
+		If[	FreeQ2[ExpandScalarProduct[aux[[2]],FCI->True],{Momentum,CartesianMomentum,TemporalMomentum}],
 			(*tadpole!*)
 			extmoms={}
 		];
 
 
-		FCPrint[1, "FCLoopIntegralToGraph: Loop momenta: ", lmoms, FCDoControl->lbtgVerbose];
-		FCPrint[1, "FCLoopIntegralToGraph: External momenta: ", extmoms, FCDoControl->lbtgVerbose];
+		FCPrint[2, "FCLoopIntegralToGraph: Loop momenta: ", lmoms, FCDoControl->lbtgVerbose];
+		FCPrint[2, "FCLoopIntegralToGraph: External momenta: ", extmoms, FCDoControl->lbtgVerbose];
+		FCPrint[2, "FCLoopIntegralToGraph: Auxiliary momenta: ", optAuxiliaryMomenta, FCDoControl->lbtgVerbose];
 
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Calling FCLoopBasisIntegralToPropagators.", FCDoControl->lbtgVerbose];
 
 		props = FCLoopBasisIntegralToPropagators[ex, lmoms, FCI->True, Tally->True];
-
+		FCPrint[1,"FCLoopIntegralToGraph: FCLoopBasisIntegralToPropagators done, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
 		FCPrint[3, "FCLoopIntegralToGraph: After FCLoopBasisIntegralToPropagators: ", props, FCDoControl->lbtgVerbose];
 
 
 		dots  = Transpose[props][[2]];
 		props = Transpose[props][[1]];
 
-		(*	TODO add Cartesian propagators *)
-		props = FeynAmpDenominatorExplicit[1/props, ExpandScalarProduct -> False, FCE -> True] // ReplaceAll[#, SPD[a_, a_] :> a] &;
 
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Calling FCLoopPropagatorsToLineMomenta.", FCDoControl->lbtgVerbose];
 		(*	Extract momenta flowing through inverse propagators, i.e. [(p-q)^2 - m^2] -> p-q *)
-		(*	TODO Suport SCET propagators *)
+		props = FCLoopPropagatorsToLineMomenta[props, FCI->True, AuxiliaryMomenta -> optAuxiliaryMomenta];
+		FCPrint[1,"FCLoopIntegralToGraph: FCLoopPropagatorsToLineMomenta done, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
 
-		lineMomenta = (SelectNotFree2[(# + null1 + null2), allmoms] & /@ props) /. null1 | null2 -> 0;
+		FCPrint[3, "FCLoopIntegralToGraph: After FCLoopPropagatorsToLineMomenta: ", props, FCDoControl->lbtgVerbose];
 
-		numEdges = Length[lineMomenta];
-		intEdgesList = Transpose[{Range[numEdges], lineMomenta}];
-		numExtMoms = Length[extmoms];
-		extEdgesList = Transpose[{-Range[numExtMoms], extmoms}];
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Generating edges and vertices.", FCDoControl->lbtgVerbose];
 
-		FCPrint[1, "FCLoopIntegralToGraph: Number of edges: ", numEdges, FCDoControl->lbtgVerbose];
 
+
+		lineMomenta 	= First[props];
+		massTerms 		= props[[2]];
+		numEdges 		= Length[lineMomenta];
+		intEdgesList	= Transpose[{Range[numEdges], lineMomenta}];
+		numExtMoms 		= Length[extmoms];
+		extEdgesList 	= Transpose[{-Range[numExtMoms], extmoms}];
+
+
+		FCPrint[2, "FCLoopIntegralToGraph: Number of edges: ", numEdges, FCDoControl->lbtgVerbose];
+		FCPrint[2, "FCLoopIntegralToGraph: Line momenta: ", lineMomenta, FCDoControl->lbtgVerbose];
 
 		(*
-			We need to enumerate the occurring momenta for the reconstruction of vertices
+			We need to enumerate the occurring momenta for the reconstruction of vertices.
 			However, as far as the external momenta are concerned, there is an additional momentum
 			which is a linear combination of the known ones.
 
-			For example, a box integral has only 3 external momenta q1,q2 and q3 but 4 legs. However,
-			as we do not enforce all momenta to be incoming, the momentum on the 4th legs can be
-			q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So we build all possible linear combinations and reconstruct
-			the corresponding vertex at the very end when all other vertices are known to avoid misreconstruction.
+			For example, a box integral has only 3 external momenta q1, q2 and q3 but 4 legs. Yet
+			as we do not enforce all momenta to be incoming, the momentum of the 4th legs can be
+			q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So to avoid misreconstruction we build all possible
+			linear combinations and reconstruct the corresponding vertex only at the very end,
+			when all other vertices are already known.
 		*)
-		numVertices = 1 + numEdges - Length[lmoms];
-		numExtVertices =  (numExtMoms+1);
-		numIntVertices = numVertices - numExtVertices;
+		numVertices 	= 1 + numEdges - Length[lmoms];
+		numExtVertices	= (numExtMoms+1);
+		numIntVertices	= numVertices - numExtVertices;
 
-		If[numExtMoms=!=0,
+		If[	numExtMoms=!=0,
 			If[	numExtMoms>1,
 					auxExternalMoms = Map[Total[Thread[Times[extmoms, #]]] &, generateSigns[numExtMoms+1]];
 					auxExtEdgesList = Transpose[{-Range[numExtMoms+1,numExtMoms+Length[auxExternalMoms]], auxExternalMoms}];
@@ -159,19 +202,20 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 			auxExtEdgesList = {}
 		];
 
-
-
+		FCPrint[1,"FCLoopIntegralToGraph: Done generating edges and vertices, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
 
 		(*	We start by reconstructing all internal vertices, i.e. those that are not connected to an external line	*)
-
 		FCPrint[1, "FCLoopIntegralToGraph: Number of internal vertices: ", numIntVertices, FCDoControl->lbtgVerbose];
 		FCPrint[1, "FCLoopIntegralToGraph: Number of external vertices: ", numExtVertices, FCDoControl->lbtgVerbose];
 
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Calling reconstructAllVertices.", FCDoControl->lbtgVerbose];
+
 		Which[
 			optFactoring === True || optFactoring === False,
-
 				factorizingIntegral = optFactoring;
 				res = reconstructAllVertices[intEdgesList,extEdgesList,auxExtEdgesList,numIntVertices,numExtVertices],
+
 			optFactoring === Auto,
 				factorizingIntegral = False;
 				res = reconstructAllVertices[intEdgesList,extEdgesList,auxExtEdgesList,numIntVertices,numExtVertices];
@@ -185,18 +229,28 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 
 		];
 
+		FCPrint[1,"FCLoopIntegralToGraph: reconstructAllVertices done, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
+
 		If[	res === False,
 			Message[FCLoopIntegralToGraph::failmsg, "Failed to reconstruct the graph of the given loop integral. If the integral factorizes, try increasing VertexDegree"];
 			Abort[]
 		];
 
+		time=AbsoluteTime[];
+		FCPrint[1,"FCLoopIntegralToGraph: Calling makeGraph.", FCDoControl->lbtgVerbose];
+
 		res = makeGraph[res];
+		FCPrint[1,"FCLoopIntegralToGraph: makeGraph done, timing:", N[AbsoluteTime[] - time, 4], FCDoControl->lbtgVerbose];
 
 		res = res /. {
-			Labeled[a_,i_Integer?Positive] :> Labeled[a, {Extract[props,{i}], Extract[dots,{i}]}],
-
-			Labeled[a_,i_Integer?Negative] :> Labeled[a, Extract[Join[auxExtEdgesList,extEdgesList],{i}][[2]]]
+			(* internal edge *)
+			labeled[a_,i_Integer?Positive] :> labeled[a, {lineMomenta[[i]], dots[[i]], massTerms[[i]]}],
+			(* external edge *)
+			labeled[a_,i_Integer?Negative] :> labeled[a, Extract[Join[auxExtEdgesList,extEdgesList],{i}][[2]]]
 		};
+
+		(*Output format: Edge rules, simple labels (line momentum, multiplicity, mass), original propagators, prefactor *)
+		res = Join[Transpose[res/.labeled->List],props[[3]],{pref}];
 
 		If[	OptionValue[FCE],
 			res = FCE[res]
@@ -206,9 +260,101 @@ FCLoopIntegralToGraph[expr_, lmomsRaw_List, OptionsPattern[]] :=
 
 	];
 
+(*
+	The following functions (except for reconstructAllVertices, obviously) are safe for memoization,
+	as their input contains only integers and names of momenta
+*)
+makeGraph[res_]:= makeGraph[res] =
+	(
+	If[	res[[1]] =!= {{}},
+		Join[Map[labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &, res[[2]]], Map[labeled[Rule[#[[2]][[1]], #[[1]]], #[[2]][[1]]] &, First /@ res[[1]]]] // Sort,
+		(Map[labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &, res[[2]]]) // Sort
+	]
+	);
+
+(*TODO: safe for memoization*)
+generateSigns[maxVertexDegree_Integer?Positive]:=
+	DeleteDuplicates[Tuples[{+1, -1}, maxVertexDegree-1], (#1 === -#2) &]/; maxVertexDegree>=3;
+
+generateCandidates[intEdgesList_List, maxVertexDegree_Integer?Positive]:=
+	generateCandidates[intEdgesList, maxVertexDegree] =
+		Subsets[intEdgesList, {maxVertexDegree-1}];
+
+checkRouting[ex_, mom_, signs_List] :=
+	checkRouting[ex, mom, signs] =
+		Flatten[Map[sum[Thread[Times[ex, #]], mom] &, signs]];
+
+sum[li_List, mom_] :=
+	sum[li, mom] =
+		SelectNotFree[Total[li] + {mom, -mom}, 0] /. 0 -> mark;
 
 
+(*Given a list of candidate edges, find those that are connected to the current edge *)
+connectEdge[{id_Integer, mom_}, candidates_List, signs_List] :=
+	connectEdge[{id, mom}, candidates, signs] =
+		SelectNotFree[Map[{Sort[Join[{id}, Transpose[#][[1]]]],	checkRouting[Transpose[#][[2]], mom, signs]} &, candidates], mark];
 
+
+findInternalVertices[intEdges_List, candidates_List, signs_List] :=
+	findInternalVertices[intEdges, candidates, signs] =
+		Block[{	intVertices, aux, res},
+
+			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Entering.", FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: intEdges: ", intEdges , FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
+
+			intVertices = {};
+			Scan[
+				(aux = connectEdge[#, candidates, signs];
+
+				(*	Remove cases where an edge appears in the list more than once	*)
+				aux = aux /. {{___,a_Integer,___,a_Integer,___},mark} -> Unevaluated[Sequence[]];
+				If[aux === {} || MatchQ[aux,{{___,a_Integer,___,a_Integer,___},mark}],
+					(* Notice that this procedure will not find vertices that involve external edges	*)
+					Unevaluated[Sequence[]]
+				];
+				FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Current edge: ", #, FCDoControl->lbtgVerbose];
+				FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Reconstructed vertices ", aux, FCDoControl->lbtgVerbose];
+				intVertices = Union[Join[intVertices, aux]];
+				) &,
+			intEdges
+			];
+
+			If[	intVertices=!={},
+				res = Transpose[intVertices],
+				res = {}
+			];
+
+			If[res=!={},
+				res = First[res]
+			];
+
+			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Leaving with: ", res, FCDoControl->lbtgVerbose];
+			res
+		];
+
+
+findExternalVertices[{}, _List, _List] :=
+	{};
+
+findExternalVertices[extEdges_List/; extEdges =!= {},  candidates_List, signs_List] :=
+	findExternalVertices[extEdges,  candidates, signs] =
+		Block[{	extVertices},
+
+			FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: Entering.", FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: extEdges: ", extEdges , FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
+			FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
+			extVertices = Union[Join @@ (connectEdge[#, candidates, signs] & /@ extEdges)];
+			FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: extVertices: ", extVertices , FCDoControl->lbtgVerbose];
+
+			(*TODO More checks*)
+			If[extVertices=!={},
+				Transpose[extVertices][[1]],
+				{}
+			]
+		];
 
 
 reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,numIntVertices_Integer,numExtVertices_Integer]:=
@@ -216,8 +362,6 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 			relEdgesList, numEdges, signs, candidates, numExtMoms, intVertexCandidateSets,
 			verticesRaw, fullyConnectedEdgesTest, auxExternalMoms, allVertices, verts,
 			rawInt, rawExt, tmp, lastExtEdge, lastExtVertex} ,
-
-
 
 		fullyConnectedEdges 	= {};
 		intVerticesFound 		= {};
@@ -230,25 +374,28 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 		numEdges 				= Length[intEdgesList];
 		numExtMoms 				= Length[extEdgesList];
 
-		FCPrint[1, "FCLoopIntegralToGraph: Reconstructing internal vertices.",  FCDoControl->lbtgVerbose];
-		FCPrint[1, "FCLoopIntegralToGraph: Internal edges: ", intEdgesList, FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructing internal vertices.",  FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Internal edges: ", intEdgesList, FCDoControl->lbtgVerbose];
 
 		currentVertexDegree = 3;
 
 		While[(Length[fullyConnectedEdges]<numEdges) && (currentVertexDegree <= maxVertexDegree)  && Length[intVerticesFound] <= numIntVertices,
 
-			FCPrint[3, "FCLoopIntegralToGraph: Searching for internal vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Searching for internal vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
 			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
 
 			signs = generateSigns[currentVertexDegree];
+
+
 			candidates = generateCandidates[If[factorizingIntegral,
 												Join[intEdgesList,intEdgesList],
 												intEdgesList
 											], currentVertexDegree];
+
 			If[candidates==={}, Break[]];
 			intVerticesFound = Join[intVerticesFound,findInternalVertices[intEdgesList, candidates, signs]];
 			fullyConnectedEdges = Cases[Tally[Flatten[intVerticesFound]], {i_Integer?Positive, 2} :> i]//Union;
-			FCPrint[3, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
 			currentVertexDegree++;
 		];
 
@@ -264,207 +411,22 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 		];
 
 		(* It is also possible that we reconstruct some fake vertices *)
-
-		FCPrint[2, "FCLoopIntegralToGraph: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
 		If[	Length[intVerticesFound] >= numIntVertices,
 			If[	numExtMoms=!=0,
-				intVertexCandidateSets = Subsets[intVerticesFound, {numIntVertices}];
-				(*fullyConnectedEdges = Cases[Tally[Flatten[intVerticesFound]], {i_Integer?Positive, 2} :> i]//Union;*)
+				intVertexCandidateSets = Subsets[intVerticesFound, {numIntVertices}]
 			];
-			FCPrint[2, "Vertex candidate sets: ", intVertexCandidateSets, FCDoControl->lbtgVerbose]
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Vertex candidate sets: ", intVertexCandidateSets, FCDoControl->lbtgVerbose]
 		];
 
-
-
-
-		FCPrint[2, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
 
 		(*	Now we only need to reconstruct the external vertices. However, there are some special cases to take care of!	*)
-
-		If[	numExtMoms=!=0,
-
-
-			FCPrint[1, "FCLoopIntegralToGraph: Reconstructing external vertices (stage I).", FCDoControl->lbtgVerbose];
-
-			(* Let us start by picking the vertices that are connected to the momenta that explicitly appear in the propagators *)
-			verticesRaw = Map[
-			(
-			(*Print["here:", #];*)
-			currentVertexDegree = 3;
-			extVerticesFound = {};
-			fullyConnectedEdges = Cases[Tally[Flatten[{#}]], {i_Integer?Positive, 2} :> i]//Union;
-			relEdgesList = intEdgesList;
-			While[(currentVertexDegree <= maxVertexDegree),
-
-			FCPrint[3, "FCLoopIntegralToGraph: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
-			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
-
-			signs = generateSigns[currentVertexDegree];
-			candidates = generateCandidates[If[factorizingIntegral,
-												Join[relEdgesList,relEdgesList],
-												relEdgesList
-											], currentVertexDegree];
-			(*
-			Print["here3:", candidates];
-			Print["here4:", signs];
-			*)
-			If[candidates==={}, Break[]];
-			extVerticesFound = Join[extVerticesFound,findExternalVertices[extEdgesList, candidates, signs]];
-			fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
-			FCPrint[3, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
-			currentVertexDegree++;
-
-			];
-
-
-			If[	numExtVertices===Length[extVerticesFound] && numExtMoms===1,
-				(*In the case of a 2-point function we can recontstruct both vertices in one run, but this is not desirable here*)
-				extVerticesFound = extVerticesFound[[1;;1]];
-				fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
-			];
-
-
-			{#,extVerticesFound} )&, intVertexCandidateSets];
-
-
-			FCPrint[2, "FCLoopIntegralToGraph: Possible vertex candidates: ", verticesRaw, FCDoControl->lbtgVerbose];
-			(*
-				It may happen that we find multiple candidates for a particular external vertex within one set.
-			*)
-
-			verticesRaw = Map[Function[x,
-
-				If[Length[x[[2]]] >= numExtVertices-1,
-
-					First[Map[{x[[1]], #} &,
-				Subsets[x[[2]], {numExtVertices-1}]]
-				],
-				x
-			]
-
-
-			], verticesRaw];
-
-			FCPrint[2, "FCLoopIntegralToGraph: Possible vertex candidates after REV I: ", verticesRaw, FCDoControl->lbtgVerbose];
-
-			verticesRaw = Select[verticesRaw, ((Length[#[[1]]] === numIntVertices) && (Length[#[[2]]] === numExtVertices - 1))&];
-
-			If[	Length[verticesRaw]===0,
-
-				(*Message[FCLoopIntegralToGraph::failmsg, "Failed to reconstruct all but one external vertices"];*)
-				Return[False]
-			];
-
-
-			(*
-				As far as the external momenta are concerned, there is an additional momentum
-				which is a linear combination of the known ones.
-
-				For example, a box integral has only 3 external momenta q1,q2 and q3 but 4 legs. However,
-				as we do not enforce all momenta to be incoming, the momentum on the 4th legs can be
-				q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So we build all possible linear combinations and reconstruct
-				the corresponding vertex at the very end when all other vertices are known. This helps to avoid misreconstruction.
-			*)
-
-			FCPrint[1, "FCLoopIntegralToGraph: Reconstructing external vertices (stage II).", FCDoControl->lbtgVerbose];
-
-
-
-
-
-			verticesRaw = Map[(
-			lastExtEdge = {};
-			currentVertexDegree = 3;
-
-			intVerticesFound = #[[1]];
-			extVerticesFound = #[[2]];
-			fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
-
-			relEdgesList = intEdgesList;
-			While[(Length[fullyConnectedEdges]<numEdges) && (currentVertexDegree <= maxVertexDegree) && Length[extVerticesFound] < (numExtVertices),
-
-			FCPrint[3, "FCLoopIntegralToGraph: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
-			relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
-
-			signs = generateSigns[currentVertexDegree];
-			candidates = generateCandidates[If[factorizingIntegral,
-												Join[relEdgesList,relEdgesList],
-												relEdgesList
-											], currentVertexDegree];
-			If[candidates==={}, Break[]];
-			(*Print["candidates: ", candidates];*)
-			lastExtVertex = findExternalVertices[auxExtEdgesList, candidates, signs];
-			(*Print[lastExtVertex];*)
-			If[	lastExtVertex=!={},
-
-				(*Print["Bingo!"];
-				Print[lastExtVertex];*)
-				lastExtVertex = lastExtVertex[[1;;1]];
-
-				(*Print[lastExtVertex];*)
-				lastExtEdge = Select[auxExtEdgesList,!FreeQ2[#[[1]],lastExtVertex[[1]]]&];
-				(*Print[lastExtEdge];*)
-				fullyConnectedEdgesTest = Cases[Tally[Flatten[{#[[1]],Join[#[[2]],lastExtVertex]}]], {i_Integer?Positive, 2} :> i]//Union;
-				(*Print[fullyConnectedEdgesTest];*)
-				If[	fullyConnectedEdgesTest===Range[numEdges],
-					Break[]
-				]
-			];
-
-			(*extVerticesFound = Join[extVerticesFound,findExternalVertices[auxExtEdgesList, candidates, signs]];*)
-			(*FCPrint[3, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];*)
-			currentVertexDegree++;
-
-			];
-
-			If[	fullyConnectedEdgesTest===Range[numEdges],
-				{#[[1]],#[[2]],lastExtVertex,lastExtEdge},
-				Unevaluated[Sequence[]]
-			]
-
-			)&, verticesRaw];
-
-
-			FCPrint[2, "FCLoopIntegralToGraph: Possible vertex candidates: REV II", verticesRaw, FCDoControl->lbtgVerbose];
-
-			If[	Length[verticesRaw]===0,
-				(*Message[FCLoopIntegralToGraph::failmsg, "Failed to connect all occurring edges to vertices."];*)
-				Return[False]
-			];
-
-			If[	Length[verticesRaw]>1,
-				Null
-				(*Message[FCLoopIntegralToGraph::failmsg, "Ambiguities in the final vertex reconstruction."];*)
-				(*Abort[]*)
-
-			];
-			(*TODO Check isomorphy?*)
-			verticesRaw= verticesRaw[[optSelect]];
-
-			lastExtEdge = verticesRaw[[4]];
-			intVerticesFound = verticesRaw[[1]];
-			extVerticesFound = Join[verticesRaw[[2]],verticesRaw[[3]]];
-
-
-
-			(*intVerticesFound = verticesRaw[[OptionValue[Select]]][[1]];
-			extVerticesFound = verticesRaw[[OptionValue[Select]]][[2]];*)
-			fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
-
-
-			FCPrint[2, "FCLoopIntegralToGraph: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
-			FCPrint[2, "FCLoopIntegralToGraph: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
-			FCPrint[2, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
-
-
-			(*Print[verticesRaw];
-			Abort[];*)
-
-			,
+		If[	numExtMoms===0,
 
 			(*	We are dealing with a tadpole!	*)
 
-			FCPrint[2, "FCLoopIntegralToGraph: Tadpole integral!", FCDoControl->lbtgVerbose];
+			FCPrint[3, "FCLoopIntegralToGraph: Tadpole integral!", FCDoControl->lbtgVerbose];
 
 			Which[
 
@@ -483,33 +445,158 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 				verticesRaw = Subsets[intVerticesFound, {numIntVertices+1}];
 				If[	Length[verticesRaw]>1,
 					Null
-					(*Message[FCLoopIntegralToGraph::failmsg, "Ambiguities in the final vertex reconstruction."];*)
-					(*Abort[]*)
 				];
-				(*TODO Check isomorphy?*)
-				intVerticesFound = verticesRaw[[optSelect]];
 
+				(* Possible ambiguities in the final vertex reconstruction: simply take the first candidate *)
+				(*	TODO Check isomorphy betwen different candidates ?*)
+				intVerticesFound = verticesRaw[[optSelect]];
 				fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union
+			],
+
+
+			(*	Our integral is not a tadpole!	*)
+
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructing external vertices (stage I).", FCDoControl->lbtgVerbose];
+			(* Let us start by picking the vertices that are connected to the momenta that explicitly appear in the propagators *)
+			verticesRaw = Map[
+				(
+				currentVertexDegree = 3;
+				extVerticesFound = {};
+				fullyConnectedEdges = Cases[Tally[Flatten[{#}]], {i_Integer?Positive, 2} :> i]//Union;
+				relEdgesList = intEdgesList;
+				While[(currentVertexDegree <= maxVertexDegree),
+					FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+					relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
+					signs = generateSigns[currentVertexDegree];
+					candidates = generateCandidates[If[	factorizingIntegral,
+														Join[relEdgesList,relEdgesList], relEdgesList],
+														currentVertexDegree
+													];
+
+					If[	candidates==={},
+						Break[]
+					];
+					extVerticesFound = Join[extVerticesFound,findExternalVertices[extEdgesList, candidates, signs]];
+					fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+					FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+					currentVertexDegree++;
+				];
+
+				If[	numExtVertices===Length[extVerticesFound] && numExtMoms===1,
+					(* Special case: In the case of a 2-point function we can recontstruct both vertices in one run, but this is not desirable here *)
+					extVerticesFound = extVerticesFound[[1;;1]];
+					fullyConnectedEdges = Cases[Tally[Flatten[{#,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+				];
+			{#,extVerticesFound} )&, intVertexCandidateSets];
+
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Possible vertex candidates: ", verticesRaw, FCDoControl->lbtgVerbose];
+
+			(*	It may happen that we find multiple candidates for a particular external vertex within one set.	*)
+			verticesRaw = Map[Function[x,
+								If[	Length[x[[2]]] >= numExtVertices-1,
+									First[Map[{x[[1]], #} &, Subsets[x[[2]], {numExtVertices-1}]]],
+									x
+								]
+							], verticesRaw];
+
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Possible vertex candidates after revision I: ", verticesRaw, FCDoControl->lbtgVerbose];
+
+			verticesRaw = Select[verticesRaw, ((Length[#[[1]]] === numIntVertices) && (Length[#[[2]]] === numExtVertices - 1))&];
+
+			If[	Length[verticesRaw]===0,
+				Return[False]
 			];
+
+			(*
+				As far as the external momenta are concerned, there is an additional momentum
+				which is a linear combination of the known ones.
+
+				For example, a box integral has only 3 external momenta q1,q2 and q3 but 4 legs. However,
+				as we do not enforce all momenta to be incoming, the momentum on the 4th legs can be
+				q1+q2+q3, q1+q2-q3, q1-q2-q3 etc. So we build all possible linear combinations and reconstruct
+				the corresponding vertex at the very end when all other vertices are known. This helps to avoid misreconstruction.
+			*)
+
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructing external vertices (stage II).", FCDoControl->lbtgVerbose];
+
+			verticesRaw = Map[
+				(
+				lastExtEdge = {};
+				currentVertexDegree = 3;
+				intVerticesFound = #[[1]];
+				extVerticesFound = #[[2]];
+				fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+				relEdgesList = intEdgesList;
+				While[(Length[fullyConnectedEdges]<numEdges) && (currentVertexDegree <= maxVertexDegree) && Length[extVerticesFound] < (numExtVertices),
+
+					FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Searching for external vertices with the vertex degree ", currentVertexDegree, FCDoControl->lbtgVerbose];
+					relEdgesList = Select[relEdgesList, FreeQ2[#[[1]], fullyConnectedEdges] &];
+					signs = generateSigns[currentVertexDegree];
+					candidates = generateCandidates[If[	factorizingIntegral,
+															Join[relEdgesList,relEdgesList], relEdgesList],
+															currentVertexDegree
+														];
+					If[	candidates==={},
+							Break[]
+					];
+					lastExtVertex = findExternalVertices[auxExtEdgesList, candidates, signs];
+					If[	lastExtVertex=!={},
+						lastExtVertex = lastExtVertex[[1;;1]];
+						lastExtEdge = Select[auxExtEdgesList,!FreeQ2[#[[1]],lastExtVertex[[1]]]&];
+						fullyConnectedEdgesTest = Cases[Tally[Flatten[{#[[1]],Join[#[[2]],lastExtVertex]}]], {i_Integer?Positive, 2} :> i]//Union;
+
+						If[	fullyConnectedEdgesTest===Range[numEdges],
+							Break[]
+						]
+					];
+					currentVertexDegree++;
+				];
+
+				If[	fullyConnectedEdgesTest===Range[numEdges],
+					{#[[1]],#[[2]],lastExtVertex,lastExtEdge},
+					Unevaluated[Sequence[]]
+				]
+
+			)&, verticesRaw];
+
+
+			FCPrint[2, "FCLoopIntegralToGraph: reconstructAllVertices: Possible vertex candidates after revision II: ", verticesRaw, FCDoControl->lbtgVerbose];
+
+			(*	Failed to connect all occurring edges to vertices. *)
+			If[	Length[verticesRaw]===0,
+				Return[False]
+			];
+
+			(* Possible ambiguities in the final vertex reconstruction: simply take the first candidate *)
+			(*	TODO Check isomorphy betwen different candidates ?*)
+
+
+			verticesRaw			= verticesRaw[[optSelect]];
+			lastExtEdge 		= verticesRaw[[4]];
+			intVerticesFound	= verticesRaw[[1]];
+			extVerticesFound	= Join[verticesRaw[[2]],verticesRaw[[3]]];
+			fullyConnectedEdges = Cases[Tally[Flatten[{intVerticesFound,extVerticesFound}]], {i_Integer?Positive, 2} :> i]//Union;
+
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructed internal vertices: ", intVerticesFound, FCDoControl->lbtgVerbose];
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
+			FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose]
 		];
 
 
-		FCPrint[2, "FCLoopIntegralToGraph: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
-		FCPrint[2, "FCLoopIntegralToGraph: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Reconstructed external vertices: ", extVerticesFound, FCDoControl->lbtgVerbose];
+		FCPrint[3, "FCLoopIntegralToGraph: reconstructAllVertices: Fully connected edges: ", fullyConnectedEdges, FCDoControl->lbtgVerbose];
 
 
+		(* Failed to connect all occurring edges to vertices *)
 		If[	fullyConnectedEdges=!=Range[numEdges],
-			(*Message[FCLoopIntegralToGraph::failmsg, "Failed to connect all occurring edges to vertices"];*)
 			Return[False]
 		];
 
-
 		allVertices = Join[extVerticesFound, intVerticesFound];
+		FCPrint[2, "FCLoopIntegralToGraph: reconstructAllVertices: All reconstructed vertices: ", allVertices, FCDoControl->lbtgVerbose];
 
-		FCPrint[2, "FCLoopIntegralToGraph: All reconstructed vertices: ", allVertices, FCDoControl->lbtgVerbose];
 
-
-		(*Range introduces labels to the vertices ... *)
+		(* Introduces labels for the vertices *)
 		verts = Transpose[{Range[Length[allVertices]], allVertices}];
 
 		If[numExtMoms=!=0,
@@ -520,8 +607,7 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 			rawExt = {{}}
 		];
 
-
-		(*Takes care of cases such as FAD[p1] FAD[p3] FAD[p1 + q1] FAD[p3 + q1] FAD[{p2 - p3, m1}] *)
+		(*	Takes care of cases such as FAD[p1] FAD[p3] FAD[p1 + q1] FAD[p3 + q1] FAD[{p2 - p3, m1}] *)
 		rawInt = Map[
 			(
 			tmp = Join[Select[verts, Function[x, ! FreeQ[x[[2]], #]]],{#}];
@@ -530,139 +616,19 @@ reconstructAllVertices[intEdgesList_List,extEdgesList_List,auxExtEdgesList_List,
 				tmp
 			]
 
-			)&, Transpose[intEdgesList][[1]]];
+			)&, Transpose[intEdgesList][[1]]
+		];
 
-
-		(*1-loop tadpole *)
+		(*	1-loop tadpole *)
 		If[	(numEdges===1) && (numExtMoms===0) && (Length[allVertices]===1) && (Length[rawInt]===1),
 			rawInt = {{{1, {1, 1}}, {1, {1, 1}},1}}
 		];
 
-		Return[{rawExt, rawInt}];
-
-
-
-
+		(* Final result, external and internal vertices *)
+		{rawExt, rawInt}
 	];
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-makeGraph[res_] := (If[res[[1]] =!= {{}},
-	Join[Map[Labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &, res[[2]]],
-		Map[Labeled[Rule[#[[2]][[1]], #[[1]]], #[[2]][[1]]] &,
-	First /@ res[[1]]]] //
-	Sort, (Map[Labeled[Rule[#[[1]][[1]], #[[2]][[1]]], #[[3]]] &,
-	res[[2]]]) // Sort]);
-
-
-
-
-
-
-
-
-(*TODO: safe for memoization*)
-generateSigns[maxVertexDegree_Integer?Positive]:=
-	DeleteDuplicates[Tuples[{+1, -1}, maxVertexDegree-1], (#1 === -#2) &]/; maxVertexDegree>=3;
-
-
-generateCandidates[intEdgesList_List, maxVertexDegree_Integer?Positive]:=
-	Subsets[intEdgesList, {maxVertexDegree-1}];
-
-
-
-checkRouting[ex_, mom_, signs_List] :=
-	Flatten[Map[sum[Thread[Times[ex, #]], mom] &, signs]];
-
-sum[li_List, mom_] :=
-	SelectNotFree[Total[li] + {mom, -mom}, 0] /. 0 -> mark;
-
-
-
-(*Given a list of candidate edges, find those that are connected to the current edge *)
-connectEdge[{id_Integer, mom_}, candidates_List, signs_List] :=
-	SelectNotFree[Map[{Sort[Join[{id}, Transpose[#][[1]]]],	checkRouting[Transpose[#][[2]], mom, signs]} &, candidates], mark];
-
-
-findInternalVertices[intEdges_List, candidates_List, signs_List] :=
-	Block[{intVertices, aux, res},
-
-		FCPrint[3, "FCLoopIntegralToGraph: findInternalVertices: Entering.", FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: intEdges: ", intEdges , FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
-
-		intVertices = {};
-		Scan[
-			(aux = connectEdge[#, candidates, signs];
-
-			(*	Remove cases where an edge appears in the list more than once	*)
-			aux = aux /. {{___,a_Integer,___,a_Integer,___},mark} -> Unevaluated[Sequence[]];
-			If[aux === {} || MatchQ[aux,{{___,a_Integer,___,a_Integer,___},mark}],
-				(* Notice that this procedure will not find vertices that involve external edges	*)
-				Unevaluated[Sequence[]]
-			];
-			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Current edge: ", #, FCDoControl->lbtgVerbose];
-			FCPrint[4, "FCLoopIntegralToGraph: findInternalVertices: Reconstructed vertices ", aux, FCDoControl->lbtgVerbose];
-			(*TODO: Once we have found all internal vertices, stop the evaluation!!! *)
-
-			(*If[Length[intVertices] >= maxVertices, Throw[intVertices]];*)
-
-			intVertices = Union[Join[intVertices, aux]];
-
-			) &,
-		intEdges
-		];
-		(*];*)
-
-		If[	intVertices=!={},
-			res = Transpose[intVertices],
-			res = {}
-		];
-
-		If[res=!={},
-
-			res = First[res]
-		];
-		FCPrint[3, "FCLoopIntegralToGraph: findInternalVertices: Leaving with: ", res, FCDoControl->lbtgVerbose];
-		res
-	];
-
-
-findExternalVertices[{}, _List, _List] :=
-	{};
-
-findExternalVertices[extEdges_List,  candidates_List, signs_List] :=
-	Block[{extVertices},
-
-
-		FCPrint[3, "FCLoopIntegralToGraph: findExternalVertices: Entering.", FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: extEdges: ", extEdges , FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: candidates: ", candidates , FCDoControl->lbtgVerbose];
-		FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: signs: ", signs , FCDoControl->lbtgVerbose];
-
-
-		extVertices = Union[Join @@ (connectEdge[#, candidates, signs] & /@ extEdges)];
-
-		FCPrint[4, "FCLoopIntegralToGraph: findExternalVertices: extVertices: ", extVertices , FCDoControl->lbtgVerbose];
-
-		(*TODO More checks*)
-		If[extVertices=!={},
-			Transpose[extVertices][[1]],
-			{}
-		]
-	];
 
 
 FCPrint[1,"FCLoopBasis.m loaded."];

--- a/FeynCalc/LoopIntegrals/FCLoopPropagatorsToLineMomenta.m
+++ b/FeynCalc/LoopIntegrals/FCLoopPropagatorsToLineMomenta.m
@@ -1,0 +1,189 @@
+(* ::Package:: *)
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ *)
+
+(* :Title: FCLoopPropagatorsToLineMomenta									*)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:	Line momenta from FeynAmpDenominators						*)
+
+(* ------------------------------------------------------------------------ *)
+
+FCLoopPropagatorsToLineMomenta::usage =
+"FCLoopPropagatorsToLineMomenta[{prop1, prop2,...}] is an auxiliary function that extracts
+line momenta flowing through the given list of propagators.";
+
+AuxiliaryMomenta::usage =
+"AuxiliaryMomenta is an option of FCLoopPropagatorsToLineMomenta it specifices auxiliary \
+momenta that do not correspond to external legs, i.e. don't really flow through the lines,
+e.g. n and nbar in SCET or v in HQET."
+
+FCLoopPropagatorsToLineMomenta::failmsg =
+"FCLoopPropagatorsToLineMomenta has encountered a fatal problem and must abort the computation. \
+The problem reads: `1`"
+
+(* ------------------------------------------------------------------------ *)
+
+Begin["`Package`"]
+End[]
+
+Begin["`FCLoopPropagatorsToLineMomenta`Private`"]
+
+ptlmVerbose::usage="";
+auxMoms::usage="";
+
+Options[FCLoopPropagatorsToLineMomenta] = {
+	AuxiliaryMomenta	-> {},
+	FCE					-> True,
+	FCI					-> False,
+	FCVerbose			-> False,
+	Expanding			-> True,
+	MomentumCombine		-> True
+};
+
+FCLoopPropagatorsToLineMomenta[expr_, OptionsPattern[]] :=
+	Block[{ex, res, fadsList, fadsListEval, repRule, fad},
+
+
+		If[	OptionValue[FCVerbose] === False,
+			ptlmVerbose = $VeryVerbose,
+			If[	MatchQ[OptionValue[FCVerbose], _Integer],
+				ptlmVerbose = OptionValue[FCVerbose]
+			];
+		];
+
+		auxMoms = OptionValue[AuxiliaryMomenta];
+		If[ Head[auxMoms]=!=List,
+			Message[FCLoopPropagatorsToLineMomenta::failmsg, "The value of the option AuxiliaryMomenta must be a list."];
+			Abort[]
+
+		];
+		If[ OptionValue[FCI],
+			ex = expr,
+			ex = FCI[expr]
+		];
+
+		If[	OptionValue[MomentumCombine],
+			ex = MomentumCombine[ex,FCI->True]
+		];
+
+		FCPrint[1, "FCLoopPropagatorsToLineMomenta: Entering.", FCDoControl->ptlmVerbose];
+		FCPrint[3, "FCLoopPropagatorsToLineMomenta: Entering with", ex,  FCDoControl->ptlmVerbose];
+
+		If[	!MatchQ[ex, {FeynAmpDenominator__}],
+			Message[FCLoopPropagatorsToLineMomenta::failmsg, "The input expression is not a valid list of propagators"];
+			Abort[]
+		];
+
+		ex = ex /. FeynAmpDenominator[(a_PropagatorDenominator)..] :> FeynAmpDenominator[a];
+
+		res = ex /. FeynAmpDenominator-> lineMomentumFromPropagator;
+
+		FCPrint[3, "FCLoopPropagatorsToLineMomenta: After lineMomentumFromPropagator", res,  FCDoControl->ptlmVerbose];
+
+		If[	!FreeQ2[res,{FeynAmpDenominator,lineMomentumFromPropagator}],
+			Message[FCLoopPropagatorsToLineMomenta::failmsg, "Some propagators could not be converted to line momenta."];
+			Abort[]
+		];
+
+		If[	OptionValue[Expanding],
+			res = ExpandAll[res]
+		];
+
+		res = Join[Transpose[res],{ex}];
+
+		If[	OptionValue[FCE],
+			res = FCE[res]
+		];
+
+		FCPrint[1, "FCLoopPropagatorsToLineMomenta: Leaving.", FCDoControl->ptlmVerbose];
+		FCPrint[1, "FCLoopPropagatorsToLineMomenta: Leaving with:", res, FCDoControl->ptlmVerbose];
+
+		res
+	];
+
+(*FAD quadratic, 1/[p^2-m^2]*)
+lineMomentumFromPropagator[PropagatorDenominator[Momentum[mom_, ___], mass_]]:=
+	{mom, -mass^2}/; FreeQ2[mom,auxMoms];
+
+(*SFAD squared, 1/[p^2-m^2] or 1/[p^2+m^2] *)
+lineMomentumFromPropagator[StandardPropagatorDenominator[Momentum[mom_, ___], 0, massSq_, {_, _}]]:=
+	{mom, massSq}/; FreeQ2[mom,auxMoms];
+
+(*CFAD squared, 1/[p^2-m^2] or 1/[p^2+m^2] *)
+lineMomentumFromPropagator[CartesianPropagatorDenominator[CartesianMomentum[mom_, ___], 0, massSq_, {_, _}]]:=
+	{mom, massSq}/; FreeQ2[mom,auxMoms];
+
+
+(*-------------------------------------------------------------*)
+
+
+(*SFAD eikonal 1/[+/- x p.q] = 2/x 1/[+/- 2 p.q]   *)
+lineMomentumFromPropagator[StandardPropagatorDenominator[0,	pref_. Pair[Momentum[a_, ___],
+	Momentum[b_, ___]], 0, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{a - b, 0},
+		{a + b, 0}
+	]/; FreeQ2[{a,b},auxMoms];
+
+(*SFAD eikonal 1/[+/- x p.q +/- m^2]  *)
+lineMomentumFromPropagator[StandardPropagatorDenominator[0,	pref_. Pair[Momentum[a_, ___],
+	Momentum[b_, ___]], massSq_, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{a - pref/2 b, massSq},
+		{a + pref/2 b, massSq}
+	]/; massSq=!=0 && FreeQ2[{a,b},auxMoms];
+
+(*SFAD eikonal 1/[p^2 +/- x p.q +/- m^2]  *)
+lineMomentumFromPropagator[StandardPropagatorDenominator[Momentum[mom_, ___],	pref_. Pair[Momentum[mom_, ___],
+	Momentum[b_, ___]], massSq_, {_, _}]]:=
+	{mom + pref/2 b, massSq}/; FreeQ2[mom,auxMoms];
+
+(*SFAD eikonal 1/[+/- v.q]  *)
+lineMomentumFromPropagator[StandardPropagatorDenominator[0,	pref_. Pair[Momentum[a_, ___],
+	Momentum[b_, ___]], massSq_, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{-a, massSq},
+		{a, massSq}
+	]/; MemberQ[auxMoms,b];
+
+
+(*-------------------------------------------------------------*)
+
+(*CFAD eikonal 1/[+/- x p.q] = 2/x 1/[+/- 2 p.q]  *)
+lineMomentumFromPropagator[CartesianPropagatorDenominator[0, pref_. CartesianPair[CartesianMomentum[a_, ___],
+	CartesianMomentum[b_, ___]], 0, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{a - b, 0},
+		{a + b, 0}
+	]/; FreeQ2[{a,b},auxMoms];
+
+(*CFAD eikonal 1/[+/- x p.q +/- m^2]  *)
+lineMomentumFromPropagator[CartesianPropagatorDenominator[0, pref_. CartesianPair[CartesianMomentum[a_, ___],
+	CartesianMomentum[b_, ___]], massSq_, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{a - pref/2 b, massSq},
+		{a + pref/2 b, massSq}
+	]/; massSq=!=0 && FreeQ2[{a,b},auxMoms];
+
+(*CFAD eikonal 1/[p^2 +/- x p.q +/- m^2]  *)
+lineMomentumFromPropagator[CartesianPropagatorDenominator[CartesianMomentum[mom_, ___],	pref_. CartesianPair[CartesianMomentum[mom_, ___],
+	CartesianMomentum[b_, ___]], massSq_, {_, _}]]:=
+	{mom + pref/2 b, massSq}/; FreeQ2[mom,auxMoms];
+
+(*CFAD eikonal 1/[+/- v.q]  *)
+lineMomentumFromPropagator[CartesianPropagatorDenominator[0,	pref_. CartesianPair[CartesianMomentum[a_, ___],
+	CartesianMomentum[b_, ___]], massSq_, {_, _}]]:=
+	If[	Internal`SyntacticNegativeQ[pref],
+		{-a, massSq},
+		{a, massSq}
+	]/; MemberQ[auxMoms,b];
+
+FCPrint[1,"FCLoopPropagatorsToLineMomenta.m loaded."];
+End[]

--- a/Tests/LoopIntegrals/FCLoopIntegralToGraph.test
+++ b/Tests/LoopIntegrals/FCLoopIntegralToGraph.test
@@ -1,0 +1,262 @@
+
+
+(* :Title: FCLoopIntegralToGraph.test                                              	    *)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for FCLoopIntegralToGraph	  		*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`LoopIntegrals`fcstFCLoopIntegralToGraph =
+({
+{"fcstFCLoopIntegralToGraph-ID1",
+"FCLoopIntegralToGraph[22 \
+SPD[q,x]SFAD[{{0,2v.q}},{q-p,m^2}],{q},AuxiliaryMomenta\[Rule]{v},FCE\
+\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 2}, {p, p, {q, 1, 0}, {-p + q, \
+1, -m^2}}, SFAD[{{0, 2*q . v}, {0, 1}, 1}], SFAD[{{-p + q, 0}, {m^2, \
+1}, 1}], 22*SPD[q, x]}"},
+{"fcstFCLoopIntegralToGraph-ID2",
+"FCLoopIntegralToGraph[CFAD[{p1,0,2},p2,q1+p1,p1-q2,q1+p1-p2,p1-p2-\
+q2,p1-p2+q1-q3],{p1,p2,p3},FCE\[Rule]True]",
+"{{-5 -> 4, -3 -> 1, -2 -> 2, -1 -> 3, 1 -> 4, 1 -> 5, 2 -> 3, 2 -> \
+6, 3 -> 5, 4 -> 6, 5 -> 6}, {q1 - q2 + q3, q1, q2, q3, {p1 - p2 + q1 \
+- q3, 1, 0}, {p1 - p2 + q1, 1, 0}, {p1, 2, 0}, {p1 - q2, 1, 0}, {p1 + \
+q1, 1, 0}, {p1 - p2 - q2, 1, 0}, {p2, 1, 0}}, CFAD[{{p2, 0}, {0, -1}, \
+1}], CFAD[{{p1, 0}, {0, -1}, 1}], CFAD[{{p1 + q1, 0}, {0, -1}, 1}], \
+CFAD[{{p1 - q2, 0}, {0, -1}, 1}], CFAD[{{p1 - p2 + q1, 0}, {0, -1}, \
+1}], CFAD[{{p1 - p2 - q2, 0}, {0, -1}, 1}], CFAD[{{p1 - p2 + q1 - q3, \
+0}, {0, -1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID3",
+"FCLoopIntegralToGraph[FAD[{p1,0,2},p2,q1+p1,p1-q2,q1+p1-p2,p1-p2-\
+q2,p1-p2+q1-q3],{p1,p2},FCE\[Rule]True]",
+"{{-5 -> 4, -3 -> 1, -2 -> 2, -1 -> 3, 1 -> 4, 1 -> 5, 2 -> 3, 2 -> \
+6, 3 -> 5, 4 -> 6, 5 -> 6}, {q1 - q2 + q3, q1, q2, q3, {p1 - p2 + q1 \
+- q3, 1, 0}, {p1 - p2 + q1, 1, 0}, {p1, 2, 0}, {p1 - q2, 1, 0}, {p1 + \
+q1, 1, 0}, {p1 - p2 - q2, 1, 0}, {p2, 1, 0}}, SFAD[{{p2, 0}, {0, 1}, \
+1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p1 + q1, 0}, {0, 1}, 1}], \
+SFAD[{{p1 - q2, 0}, {0, 1}, 1}], SFAD[{{p1 - p2 + q1, 0}, {0, 1}, \
+1}], SFAD[{{p1 - p2 - q2, 0}, {0, 1}, 1}], SFAD[{{p1 - p2 + q1 - q3, \
+0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID4",
+"FCLoopIntegralToGraph[SFAD[p1,Q-p1,p2,Q-p2],{p1,p2},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 3, 2 -> 3, 2 -> 3}, {Q, Q, \
+{p2, 1, 0}, {-p2 + Q, 1, 0}, {p1, 1, 0}, {-p1 + Q, 1, 0}}, SFAD[{{p2, \
+0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{-p2 + Q, 0}, {0, \
+1}, 1}], SFAD[{{-p1 + Q, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID5",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p2] FAD[p1-p2],{p1,p2},FCE\
+\[Rule]True]",
+"{{1 -> 2, 1 -> 2, 1 -> 2}, {{p2, 1, 0}, {p1, 1, 0}, {p1 - p2, 1, \
+0}}, SFAD[{{p2, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], \
+SFAD[{{p1 - p2, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID6",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p4] FAD[p1+q1] FAD[p3+p4+q1] \
+FAD[p3] FAD[p1-p4],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 2 -> 4, 3 -> \
+4}, {q1, q1, {p1, 1, 0}, {p1 + q1, 1, 0}, {p4, 1, 0}, {p3, 1, 0}, {p3 \
++ p4 + q1, 1, 0}, {p1 - p4, 1, 0}}, SFAD[{{p4, 0}, {0, 1}, 1}], \
+SFAD[{{p3, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p1 + \
+q1, 0}, {0, 1}, 1}], SFAD[{{p1 - p4, 0}, {0, 1}, 1}], SFAD[{{p3 + p4 \
++ q1, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID7",
+"FCLoopIntegralToGraph[SFAD[p1,p1-Q,p3-Q,p1-p3,p3],{p1,p3},FCE\
+\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4}, {Q, \
+Q, {p3, 1, 0}, {p3 - Q, 1, 0}, {p1, 1, 0}, {p1 - Q, 1, 0}, {p1 - p3, \
+1, 0}}, SFAD[{{p3, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], \
+SFAD[{{p3 - Q, 0}, {0, 1}, 1}], SFAD[{{p1 - Q, 0}, {0, 1}, 1}], \
+SFAD[{{p1 - p3, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID8",
+"FCLoopIntegralToGraph[SFAD[p1,p3,p1,Q-p1,p1-p3],{p1,p3},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 3, 2 -> 3, 2 -> 3}, {Q, Q, \
+{-p1 + Q, 1, 0}, {p1, 2, 0}, {p3, 1, 0}, {p1 - p3, 1, 0}}, SFAD[{{p3, \
+0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{-p1 + Q, 0}, {0, \
+1}, 1}], SFAD[{{p1 - p3, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID9",
+"FCLoopIntegralToGraph[SFAD[p1,Q-p1,p3,Q-p3],{p1,p3},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 3, 2 -> 3, 2 -> 3}, {Q, Q, \
+{p3, 1, 0}, {-p3 + Q, 1, 0}, {p1, 1, 0}, {-p1 + Q, 1, 0}}, SFAD[{{p3, \
+0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{-p3 + Q, 0}, {0, \
+1}, 1}], SFAD[{{-p1 + Q, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID10",
+"FCLoopIntegralToGraph[FAD[{p1,0},{p2,0},{p3,0},{p1-p2},{p2+p3},{\
+p2+p3-p1}],{p1,p2,p3},FCE\[Rule]True]",
+"{{1 -> 2, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4}, {{p3, 1, 0}, \
+{p2, 1, 0}, {p2 + p3, 1, 0}, {p1 - p2, 1, 0}, {-p1 + p2 + p3, 1, 0}, \
+{p1, 1, 0}}, SFAD[{{p3, 0}, {0, 1}, 1}], SFAD[{{p2, 0}, {0, 1}, 1}], \
+SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p2 + p3, 0}, {0, 1}, 1}], \
+SFAD[{{p1 - p2, 0}, {0, 1}, 1}], SFAD[{{-p1 + p2 + p3, 0}, {0, 1}, \
+1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID11",
+"FCLoopIntegralToGraph[SFAD[p1,p2,q1+p1,p1-q2,q1+p1-p2,p1-p2-q2],{\
+p1,p2},FCE\[Rule]True]",
+"{{-3 -> 3, -2 -> 1, -1 -> 2, 1 -> 2, 1 -> 5, 2 -> 4, 3 -> 4, 3 -> \
+5, 4 -> 5}, {q1 - q2, q1, q2, {p1, 1, 0}, {p1 - q2, 1, 0}, {p1 + q1, \
+1, 0}, {p1 - p2 + q1, 1, 0}, {p1 - p2 - q2, 1, 0}, {p2, 1, 0}}, \
+SFAD[{{p2, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p1 + \
+q1, 0}, {0, 1}, 1}], SFAD[{{p1 - q2, 0}, {0, 1}, 1}], SFAD[{{p1 - p2 \
++ q1, 0}, {0, 1}, 1}], SFAD[{{p1 - p2 - q2, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID12",
+"FCLoopIntegralToGraph[FAD[p1,{Q+p1,m1},p2,Q+p1-p2,{Q+p1,m2}],{p1,\
+p2},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4, 3 -> 4}, {Q, \
+Q, {p1, 1, 0}, {p1 + Q, 1, -m2^2}, {p1 + Q, 1, -m1^2}, {p2, 1, 0}, \
+{p1 - p2 + Q, 1, 0}}, SFAD[{{p2, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, \
+1}, 1}], SFAD[{{p1 + Q, 0}, {m2^2, 1}, 1}], SFAD[{{p1 + Q, 0}, {m1^2, \
+1}, 1}], SFAD[{{p1 - p2 + Q, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID13",
+"FCLoopIntegralToGraph[FAD[{p1,m1}],{p1},FCE\[Rule]True]",
+"{{1 -> 1}, {{p1, 1, -m1^2}}, SFAD[{{p1, 0}, {m1^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID14",
+"FCLoopIntegralToGraph[FAD[{p1,m1},{p2,m2},{p1+p2,0}],{p1,p2},FCE\
+\[Rule]True]",
+"{{1 -> 2, 1 -> 2, 1 -> 2}, {{p1 + p2, 1, 0}, {p2, 1, -m2^2}, {p1, \
+1, -m1^2}}, SFAD[{{p1 + p2, 0}, {0, 1}, 1}], SFAD[{{p2, 0}, {m2^2, \
+1}, 1}], SFAD[{{p1, 0}, {m1^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID15",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p1-p3-p4] FAD[p4] FAD[p3+p4+q1] \
+FAD[{p3,m1}] FAD[{p1-p4,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> \
+4}, {q1, q1, {p3 + p4 + q1, 1, 0}, {p4, 1, 0}, {p3, 1, -m1^2}, {p1, \
+1, 0}, {p1 - p3 - p4, 1, 0}, {p1 - p4, 1, -m1^2}}, SFAD[{{p4, 0}, {0, \
+1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p3, 0}, {m1^2, 1}, 1}], \
+SFAD[{{p3 + p4 + q1, 0}, {0, 1}, 1}], SFAD[{{p1 - p4, 0}, {m1^2, 1}, \
+1}], SFAD[{{p1 - p3 - p4, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID16",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p1-p3-p4] FAD[p4] FAD[p1+q1] \
+FAD[p3+q1] FAD[{p3,m1}] FAD[{p1-p4,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 5, 2 -> 4, 2 -> 5, 3 -> 4, 3 -> \
+5, 4 -> 5}, {q1, q1, {p1, 1, 0}, {p1 + q1, 1, 0}, {p3, 1, -m1^2}, {p3 \
++ q1, 1, 0}, {p1 - p4, 1, -m1^2}, {p4, 1, 0}, {p1 - p3 - p4, 1, 0}}, \
+SFAD[{{p4, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p3 + \
+q1, 0}, {0, 1}, 1}], SFAD[{{p1 + q1, 0}, {0, 1}, 1}], SFAD[{{p3, 0}, \
+{m1^2, 1}, 1}], SFAD[{{p1 - p4, 0}, {m1^2, 1}, 1}], SFAD[{{p1 - p3 - \
+p4, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID17",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p1-p3-p4] FAD[p4] FAD[p1+q1] \
+FAD[p3+q1] FAD[{p3,m1}] FAD[{p1-p4,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 5, 2 -> 4, 2 -> 5, 3 -> 4, 3 -> \
+5, 4 -> 5}, {q1, q1, {p1, 1, 0}, {p1 + q1, 1, 0}, {p3, 1, -m1^2}, {p3 \
++ q1, 1, 0}, {p1 - p4, 1, -m1^2}, {p4, 1, 0}, {p1 - p3 - p4, 1, 0}}, \
+SFAD[{{p4, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], SFAD[{{p3 + \
+q1, 0}, {0, 1}, 1}], SFAD[{{p1 + q1, 0}, {0, 1}, 1}], SFAD[{{p3, 0}, \
+{m1^2, 1}, 1}], SFAD[{{p1 - p4, 0}, {m1^2, 1}, 1}], SFAD[{{p1 - p3 - \
+p4, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID18",
+"FCLoopIntegralToGraph[FAD[p1] FAD[p1-p3-p4] FAD[p3+q1] \
+FAD[p3+p4+q1] FAD[{p3,m1}] \
+FAD[{p1-p4,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 2 -> 4, 3 -> \
+4}, {q1, q1, {p3, 1, -m1^2}, {p3 + q1, 1, 0}, {p1 - p3 - p4, 1, 0}, \
+{p1, 1, 0}, {p3 + p4 + q1, 1, 0}, {p1 - p4, 1, -m1^2}}, SFAD[{{p1, \
+0}, {0, 1}, 1}], SFAD[{{p3 + q1, 0}, {0, 1}, 1}], SFAD[{{p3, 0}, \
+{m1^2, 1}, 1}], SFAD[{{p3 + p4 + q1, 0}, {0, 1}, 1}], SFAD[{{p1 - p4, \
+0}, {m1^2, 1}, 1}], SFAD[{{p1 - p3 - p4, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID19",
+"FCLoopIntegralToGraph[FAD[p1-p4] FAD[p1+q1] FAD[p3+q1] \
+FAD[p3+p4+q1] FAD[{p1,m1}] FAD[{p3,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4, 3 -> \
+4}, {q1, q1, {p3 + q1, 1, 0}, {p3, 1, -m1^2}, {p1, 1, -m1^2}, {p1 + \
+q1, 1, 0}, {p1 - p4, 1, 0}, {p3 + p4 + q1, 1, 0}}, SFAD[{{p3 + q1, \
+0}, {0, 1}, 1}], SFAD[{{p1 + q1, 0}, {0, 1}, 1}], SFAD[{{p3, 0}, \
+{m1^2, 1}, 1}], SFAD[{{p1, 0}, {m1^2, 1}, 1}], SFAD[{{p1 - p4, 0}, \
+{0, 1}, 1}], SFAD[{{p3 + p4 + q1, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID20",
+"FCLoopIntegralToGraph[FAD[p3] FAD[p1-p3-p4] FAD[p4] FAD[p3+q1] \
+FAD[p3+p4+q1] FAD[{p1,m1}],{p1,p3,p4},FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 2 -> 4, 3 -> \
+4}, {q1, q1, {p3 + q1, 1, 0}, {p3, 1, 0}, {p3 + p4 + q1, 1, 0}, {p1, \
+1, -m1^2}, {p1 - p3 - p4, 1, 0}, {p4, 1, 0}}, SFAD[{{p4, 0}, {0, 1}, \
+1}], SFAD[{{p3, 0}, {0, 1}, 1}], SFAD[{{p3 + q1, 0}, {0, 1}, 1}], \
+SFAD[{{p1, 0}, {m1^2, 1}, 1}], SFAD[{{p3 + p4 + q1, 0}, {0, 1}, 1}], \
+SFAD[{{p1 - p3 - p4, 0}, {0, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID21",
+"FCLoopIntegralToGraph[FAD[p1,p2,p3,p1+p2,p1+p2+p3],{p1,p2,p3},FCE\
+\[Rule]True]",
+"{{1 -> 2, 1 -> 3, 1 -> 3, 2 -> 3, 2 -> 3}, {{p1 + p2, 1, 0}, {p3, \
+1, 0}, {p1 + p2 + p3, 1, 0}, {p2, 1, 0}, {p1, 1, 0}}, SFAD[{{p3, 0}, \
+{0, 1}, 1}], SFAD[{{p2, 0}, {0, 1}, 1}], SFAD[{{p1, 0}, {0, 1}, 1}], \
+SFAD[{{p1 + p2, 0}, {0, 1}, 1}], SFAD[{{p1 + p2 + p3, 0}, {0, 1}, \
+1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID22",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},{k1-k2},{k2,mg},{k3,mb},{k2-k3,mb}],{k1,k2,k3},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 2, 1 -> 3, 2 -> 3, 2 -> 3}, \
+{q, q, {-k1 + q, 1, 0}, {k1 - k2, 1, 0}, {k2, 1, -mg^2}, {k3, 1, \
+-mb^2}, {k2 - k3, 1, -mb^2}}, SFAD[{{k3, 0}, {mb^2, 1}, 1}], \
+SFAD[{{k2, 0}, {mg^2, 1}, 1}], SFAD[{{-k1 + q, 0}, {0, 1}, 1}], \
+SFAD[{{k1 - k2, 0}, {0, 1}, 1}], SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], \
+1}"},
+{"fcstFCLoopIntegralToGraph-ID23",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},{k1-k2},{k2,mg},{k3,mb},{k2-k3,mb},{q-k2,mb}],{k1,k2,k3},\
+FCE\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 3, 2 -> 4, 2 -> \
+4}, {q, q, {k2, 1, -mg^2}, {-k2 + q, 1, -mb^2}, {k3, 1, -mb^2}, {k2 - \
+k3, 1, -mb^2}, {-k1 + q, 1, 0}, {k1 - k2, 1, 0}}, SFAD[{{k3, 0}, \
+{mb^2, 1}, 1}], SFAD[{{k2, 0}, {mg^2, 1}, 1}], SFAD[{{-k1 + q, 0}, \
+{0, 1}, 1}], SFAD[{{k1 - k2, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, \
+{mb^2, 1}, 1}], SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID24",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},k1,{k2,mg},{k3,mb},{k2-k3,mb}],{k1,k2,k3},FCE\[Rule]True]",
+	"{{-3 -> 2, -1 -> 1, 1 -> 2, 1 -> 2, 2 -> 3, 2 -> 3, 2 -> 3}, {q, \
+q, {k1, 1, 0}, {-k1 + q, 1, 0}, {k3, 1, -mb^2}, {k2, 1, -mg^2}, {k2 - \
+k3, 1, -mb^2}}, SFAD[{{k1, 0}, {0, 1}, 1}], SFAD[{{k3, 0}, {mb^2, 1}, \
+1}], SFAD[{{k2, 0}, {mg^2, 1}, 1}], SFAD[{{-k1 + q, 0}, {0, 1}, 1}], \
+SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID25",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},k1,{k2,mg},{k3,mb},{k2-k3,mb},{q-k2,mb}],{k1,k2,k3},FCE\
+\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 4, 1 -> 4, 2 -> 3, 2 -> 3, 2 -> 4, 3 -> \
+4}, {q, q, {k1, 1, 0}, {-k1 + q, 1, 0}, {k3, 1, -mb^2}, {k2 - k3, 1, \
+-mb^2}, {-k2 + q, 1, -mb^2}, {k2, 1, -mg^2}}, SFAD[{{k1, 0}, {0, 1}, \
+1}], SFAD[{{k3, 0}, {mb^2, 1}, 1}], SFAD[{{k2, 0}, {mg^2, 1}, 1}], \
+SFAD[{{-k1 + q, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, {mb^2, 1}, 1}], \
+SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID26",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},k1,{k3,mb},{k2-k3,mb},{q-k2,mb}],{k1,k2,k3},FCE\[Rule]True]\
+", "{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 3, 2 -> 3, 2 -> 3, 2 -> 3}, {q, \
+q, {k1, 1, 0}, {-k1 + q, 1, 0}, {k3, 1, -mb^2}, {-k2 + q, 1, -mb^2}, \
+{k2 - k3, 1, -mb^2}}, SFAD[{{k1, 0}, {0, 1}, 1}], SFAD[{{k3, 0}, \
+{mb^2, 1}, 1}], SFAD[{{-k1 + q, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, \
+{mb^2, 1}, 1}], SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID27",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},k1,k1-k2,{k3,mb},{k2-k3,mb},{q-k2,mb}],{k1,k2,k3},FCE\
+\[Rule]True]",
+"{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 2 -> 4, 3 -> \
+4}, {q, q, {-k1 + q, 1, 0}, {k1, 1, 0}, {-k2 + q, 1, -mb^2}, {k3, 1, \
+-mb^2}, {k2 - k3, 1, -mb^2}, {k1 - k2, 1, 0}}, SFAD[{{k1, 0}, {0, 1}, \
+1}], SFAD[{{k3, 0}, {mb^2, 1}, 1}], SFAD[{{-k1 + q, 0}, {0, 1}, 1}], \
+SFAD[{{k1 - k2, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, {mb^2, 1}, 1}], \
+SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID28",
+"FCLoopIntegralToGraph[ \
+FAD[{q-k1},k1,q-k2,k2,{k2-k3,mb},{k1-k3,mb}],{k1,k2,k3},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4, \
+3 -> 4}, {q, q, {k2, 1, 0}, {-k2 + q, 1, 0}, {k1, 1, 0}, {-k1 + q, 1, \
+0}, {k2 - k3, 1, -mb^2}, {k1 - k3, 1, -mb^2}}, SFAD[{{k2, 0}, {0, 1}, \
+1}], SFAD[{{k1, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, {0, 1}, 1}], \
+SFAD[{{-k1 + q, 0}, {0, 1}, 1}], SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], \
+SFAD[{{k1 - k3, 0}, {mb^2, 1}, 1}], 1}"},
+{"fcstFCLoopIntegralToGraph-ID29",
+"FCLoopIntegralToGraph[SPD[k3] \
+FAD[{q-k1},k1,q-k2,k2,{k2-k3,mb},{k1-k3,mb}],{k1,k2,k3},FCE\[Rule]\
+True]", "{{-3 -> 2, -1 -> 1, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4, \
+3 -> 4}, {q, q, {k2, 1, 0}, {-k2 + q, 1, 0}, {k1, 1, 0}, {-k1 + q, 1, \
+0}, {k2 - k3, 1, -mb^2}, {k1 - k3, 1, -mb^2}}, SFAD[{{k2, 0}, {0, 1}, \
+1}], SFAD[{{k1, 0}, {0, 1}, 1}], SFAD[{{-k2 + q, 0}, {0, 1}, 1}], \
+SFAD[{{-k1 + q, 0}, {0, 1}, 1}], SFAD[{{k2 - k3, 0}, {mb^2, 1}, 1}], \
+SFAD[{{k1 - k3, 0}, {mb^2, 1}, 1}], SPD[k3, k3]}"}
+})
+

--- a/Tests/LoopIntegrals/FCLoopPropagatorsToLineMomenta.test
+++ b/Tests/LoopIntegrals/FCLoopPropagatorsToLineMomenta.test
@@ -1,0 +1,250 @@
+
+
+(* :Title: PropagatorsToLineMomenta.test                         		    *)
+
+(*
+	This software is covered by the GNU General Public License 3.
+	Copyright (C) 1990-2020 Rolf Mertig
+	Copyright (C) 1997-2020 Frederik Orellana
+	Copyright (C) 2014-2020 Vladyslav Shtabovenko
+*)
+
+(* :Summary:  Framework independent unit tests for
+				PropagatorsToLineMomenta									*)
+
+(* ------------------------------------------------------------------------ *)
+
+Tests`LoopIntegrals`fcstFCLoopPropagatorsToLineMomenta =
+({
+{"fcstFCLoopPropagatorsToLineMomenta-ID1",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q,m^2}],SFAD[{p,-m^2}]},\
+FCE->True]",
+"{{q, p}, {-m^2, m^2}, {SFAD[{{q, 0}, {m^2, 1}, 1}], SFAD[{{p, 0}, \
+{-m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID2",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q,m}]},FCE->True]",
+"{{q}, {-m^2}, {FAD[{q, m}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID3",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q+p,m}]},FCE->True]",
+"{{p + q}, {-m^2}, {FAD[{p + q, m}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID4",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q-p,m}]},FCE->True]",
+"{{-p + q}, {-m^2}, {FAD[{-p + q, m}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID5",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q+p,0}]},FCE->True]",
+"{{p + q}, {0}, {FAD[p + q]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID6",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q-p,0}]},FCE->True]",
+"{{-p + q}, {0}, {FAD[-p + q]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID7",
+"FCLoopPropagatorsToLineMomenta[{FAD[{q,m,2}]},FCE->True]",
+"{{q}, {-m^2}, {FAD[{q, m}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID8",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q,m}]},FCE->True]",
+"{{q}, {-m}, {SFAD[{{q, 0}, {m, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID9",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q+p,m}]},FCE->True]",
+"{{p + q}, {-m}, {SFAD[{{p + q, 0}, {m, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID10",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q-p,m}]},FCE->True]",
+"{{-p + q}, {-m}, {SFAD[{{-p + q, 0}, {m, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID11",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q+p,0}]},FCE->True]",
+"{{p + q}, {0}, {SFAD[{{p + q, 0}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID12",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q-p,0}]},FCE->True]",
+"{{-p + q}, {0}, {SFAD[{{-p + q, 0}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID13",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{q,m,2}]},FCE->True]",
+"{{q}, {-m}, {SFAD[{{q, 0}, {m, 1}, 2}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID14",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q,m}]},FCE->True]",
+"{{q}, {m}, {CFAD[{{q, 0}, {m, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID15",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q+p,m}]},FCE->True]",
+"{{p + q}, {m}, {CFAD[{{p + q, 0}, {m, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID16",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q-p,m}]},FCE->True]",
+"{{-p + q}, {m}, {CFAD[{{-p + q, 0}, {m, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID17",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q+p,0}]},FCE->True]",
+"{{p + q}, {0}, {CFAD[{{p + q, 0}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID18",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q-p,0}]},FCE->True]",
+"{{-p + q}, {0}, {CFAD[{{-p + q, 0}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID19",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{q,m,2}]},FCE->True]",
+"{{q}, {m}, {CFAD[{{q, 0}, {m, -1}, 2}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID20",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2p.q}}]},FCE->True]",
+"{{p + q}, {0}, {SFAD[{{0, 2*p . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID21",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-2p.q}}]},FCE->True]",
+"{{p - q}, {0}, {SFAD[{{0, -2*p . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID22",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2(p+l).q}}]},FCE->True]",
+	"{{l + p + q}, {0}, {SFAD[{{0, 2*(l + p) . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID23",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-2(p+l).q}}]},FCE->True]\
+", "{{l + p - q}, {0}, {SFAD[{{0, -2*(l + p) . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID24",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,5p.q}}]},FCE->True]",
+"{{p + q}, {0}, {SFAD[{{0, 5*p . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID25",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-5p.q}}]},FCE->True]",
+"{{p - q}, {0}, {SFAD[{{0, -5*p . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID26",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,5(p+l).q}}]},FCE->True]",
+	"{{l + p + q}, {0}, {SFAD[{{0, 5*(l + p) . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID27",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-5(p+l).q}}]},FCE->True]\
+", "{{l + p - q}, {0}, {SFAD[{{0, -5*(l + p) . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID28",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,2(p+l).q}}]},FCE->True]\
+", "{{l + p + q}, {0}, {SFAD[{{l + p, 2*(l + p) . q}, {0, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID29",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,-2(p+l).q}}]},\
+FCE->True]",
+"{{l + p - q}, {0}, {SFAD[{{l + p, -2*(l + p) . q}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID30",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,-3(p+l).q}}]},\
+FCE->True]",
+"{{l + p - (3*q)/2}, {0}, {SFAD[{{l + p, -3*(l + p) . q}, {0, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID31",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,1/2(p+l).q}}]},\
+FCE->True]",
+"{{l + p + q/4}, {0}, {SFAD[{{l + p, (l + p) . q/2}, {0, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID32",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2p.q},m^2}]},FCE->True]",
+	"{{p + q}, {-m^2}, {SFAD[{{0, 2*p . q}, {m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID33",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-2p.q},m^2}]},FCE->True]\
+", "{{p + q}, {-m^2}, {SFAD[{{0, -2*p . q}, {m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID34",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,5p.q},m^2}]},FCE->True]",
+	"{{p + (5*q)/2}, {-m^2}, {SFAD[{{0, 5*p . q}, {m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID35",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,-5p.q},m^2}]},FCE->True]\
+", "{{p + (5*q)/2}, {-m^2}, {SFAD[{{0, -5*p . q}, {m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID36",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,2(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p + q}, {-m^2}, {SFAD[{{l + p, 2*(l + p) . q}, {m^2, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID37",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,-2(p+l).q},-m^2}]},\
+FCE->True]",
+"{{l + p - q}, {m^2}, {SFAD[{{l + p, -2*(l + p) . q}, {-m^2, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID38",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,-3(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p - (3*q)/2}, {-m^2}, {SFAD[{{l + p, -3*(l + p) . q}, {m^2, \
+1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID39",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{p+l,1/2(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p + q/4}, {-m^2}, {SFAD[{{l + p, (l + p) . q/2}, {m^2, 1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID40",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2p.q}}]},FCE->True]",
+"{{p + q}, {0}, {CFAD[{{0, 2*p . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID41",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-2p.q}}]},FCE->True]",
+"{{p - q}, {0}, {CFAD[{{0, -2*p . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID42",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2(p+l).q}}]},FCE->True]",
+	"{{l + p + q}, {0}, {CFAD[{{0, 2*(l + p) . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID43",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-2(p+l).q}}]},FCE->True]\
+", "{{l + p - q}, {0}, {CFAD[{{0, -2*(l + p) . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID44",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,5p.q}}]},FCE->True]",
+"{{p + q}, {0}, {CFAD[{{0, 5*p . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID45",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-5p.q}}]},FCE->True]",
+"{{p - q}, {0}, {CFAD[{{0, -5*p . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID46",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,5(p+l).q}}]},FCE->True]",
+	"{{l + p + q}, {0}, {CFAD[{{0, 5*(l + p) . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID47",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-5(p+l).q}}]},FCE->True]\
+", "{{l + p - q}, {0}, {CFAD[{{0, -5*(l + p) . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID48",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,2(p+l).q}}]},FCE->True]\
+", "{{l + p + q}, {0}, {CFAD[{{l + p, 2*(l + p) . q}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID49",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,-2(p+l).q}}]},\
+FCE->True]",
+"{{l + p - q}, {0}, {CFAD[{{l + p, -2*(l + p) . q}, {0, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID50",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,-3(p+l).q}}]},\
+FCE->True]",
+"{{l + p - (3*q)/2}, {0}, {CFAD[{{l + p, -3*(l + p) . q}, {0, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID51",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,1/2(p+l).q}}]},\
+FCE->True]",
+"{{l + p + q/4}, {0}, {CFAD[{{l + p, (l + p) . q/2}, {0, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID52",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2p.q},m^2}]},FCE->True]",
+	"{{p + q}, {m^2}, {CFAD[{{0, 2*p . q}, {m^2, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID53",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-2p.q},m^2}]},FCE->True]\
+", "{{p + q}, {m^2}, {CFAD[{{0, -2*p . q}, {m^2, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID54",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,5p.q},m^2}]},FCE->True]",
+	"{{p + (5*q)/2}, {m^2}, {CFAD[{{0, 5*p . q}, {m^2, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID55",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,-5p.q},m^2}]},FCE->True]\
+", "{{p + (5*q)/2}, {m^2}, {CFAD[{{0, -5*p . q}, {m^2, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID56",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,2(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p + q}, {m^2}, {CFAD[{{l + p, 2*(l + p) . q}, {m^2, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID57",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,-2(p+l).q},-m^2}]},\
+FCE->True]",
+"{{l + p - q}, {-m^2}, {CFAD[{{l + p, -2*(l + p) . q}, {-m^2, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID58",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,-3(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p - (3*q)/2}, {m^2}, {CFAD[{{l + p, -3*(l + p) . q}, {m^2, \
+-1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID59",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{p+l,1/2(p+l).q},m^2}]},\
+FCE->True]",
+"{{l + p + q/4}, {m^2}, {CFAD[{{l + p, (l + p) . q/2}, {m^2, -1}, \
+1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID60",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2v.q}}]},FCE->True,\
+AuxiliaryMomenta\[Rule]{v}]",
+"{{q}, {0}, {SFAD[{{0, 2*q . v}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID61",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2v.(q+r)}}]},FCE->True,\
+AuxiliaryMomenta\[Rule]{v}]",
+"{{q + r}, {0}, {SFAD[{{0, 2*(q + r) . v}, {0, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID62",
+"FCLoopPropagatorsToLineMomenta[{SFAD[{{0,2v.(q+r)},m^2}]},\
+FCE->True,AuxiliaryMomenta\[Rule]{v}]",
+"{{q + r}, {-m^2}, {SFAD[{{0, 2*(q + r) . v}, {m^2, 1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID63",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2v.q}}]},FCE->True,\
+AuxiliaryMomenta\[Rule]{v}]",
+"{{q}, {0}, {CFAD[{{0, 2*q . v}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID64",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2v.(q+r)}}]},FCE->True,\
+AuxiliaryMomenta\[Rule]{v}]",
+"{{q + r}, {0}, {CFAD[{{0, 2*(q + r) . v}, {0, -1}, 1}]}}"},
+{"fcstFCLoopPropagatorsToLineMomenta-ID65",
+"FCLoopPropagatorsToLineMomenta[{CFAD[{{0,2v.(q+r)},m^2}]},\
+FCE->True,AuxiliaryMomenta\[Rule]{v}]",
+"{{q + r}, {m^2}, {CFAD[{{0, 2*(q + r) . v}, {m^2, -1}, 1}]}}"}
+});


### PR DESCRIPTION
Initial version of FCLoopBasisIntegralToGraph, a function that converts a propagator representation of a loop 
integral to a graph representation.  The output is a list of edge rules that can immediately processed via 
Mathematica's `GraphPlot`

Usage examples:

```
FAD[p1, p2, q1 + p1, p1 - q2, q1 + p1 - p2, p1 - p2 - q2, 
 p1 - p2 + q1 - q3]
re = FCLoopBasisIntegralToGraph[%, {p1, p2}]
GraphPlot[%]
```

```
FAD[p1] FAD[p4] FAD[p1 + q1] FAD[p3 + p4 + q1] FAD[p3] FAD[p1 - p4]
FCLoopBasisIntegralToGraph[%, {p1, p3, p4}, FCVerbose -> 0]
GraphPlot[%]
```

```
SFAD[p1, p2, q1 + p1, p1 - q2, q1 + p1 - p2, p1 - p2 - q2]
FCLoopBasisIntegralToGraph[%, {p1, p2}]
GraphPlot[%]
```

ToDo

- [x] The code works but still requires a lot of polishing
- [x] Support CFADs and especially eikonal propagators
- [ ] If the line momentum flowing through the propagator is unclear, add an option to specify it explicitly
- [x] Better debugging output and more comments
- [ ] Additional output styles/modes (e.g. for GraphViz, EXP etc.)
- [x] Unit tests
- [x] Documentation
- [ ] Mention similar codes somewhere (important for the paper): [PlanarityTest](https://prac.us.edu.pl/~gluza/ambre/planarity/), [GraphRoutines](https://github.com/ValentinHirschi/alphaLoopMisc/commit/a3b056bd505ec2a3cd8d5edb15e5cca93c18e8de) (is it public???)
- [ ] A connection to [IGraph/M](http://szhorvat.net/pelican/igraphm-a-mathematica-interface-for-igraph.html) as in GraphRoutines would be a good idea
- [x]  Use the U and F Polynomials to determine external momenta that really contribute (important e.g. for tadpoles). Requires the merge of #58 !
- [ ] A front-end function for generating nice plots with proper line labelling


