### PR TITLE
Removed error due to Mandelstam setting for 3 QCD Examples.

### DIFF
--- a/FeynCalc/Examples/QCD/Tree/ElAel-QQbar.m
+++ b/FeynCalc/Examples/QCD/Tree/ElAel-QQbar.m
@@ -75,8 +75,8 @@ amp[0] = FCFAConvert[CreateFeynAmp[diags], IncomingMomenta->{p1,p2},
 
 
 FCClearScalarProducts[];
-SetMandelstam[s, t, u, p1, p2, -k1, -k2, SMP["m_e"]^2, SMP["m_e"]^2,
-	SMP["m_q"]^2, SMP["m_q"]^2];
+SetMandelstam[s, t, u, p1, p2, -k1, -k2, SMP["m_e"], SMP["m_e"],
+	SMP["m_q"], SMP["m_q"]];
 
 
 (* ::Section:: *)

--- a/FeynCalc/Examples/QCD/Tree/GlGl-QQbar.m
+++ b/FeynCalc/Examples/QCD/Tree/GlGl-QQbar.m
@@ -75,7 +75,7 @@ amp[0] = FCFAConvert[CreateFeynAmp[diags], IncomingMomenta->{p1,p2},
 
 
 FCClearScalarProducts[];
-SetMandelstam[s, t, u, p1, p2, -k1, -k2, 0, 0, SMP["m_u"]^2, SMP["m_u"]^2];
+SetMandelstam[s, t, u, p1, p2, -k1, -k2, 0, 0, SMP["m_u"], SMP["m_u"]];
 
 
 (* ::Section:: *)

--- a/FeynCalc/Examples/QCD/Tree/MuAmu-QQbar.m
+++ b/FeynCalc/Examples/QCD/Tree/MuAmu-QQbar.m
@@ -75,8 +75,8 @@ amp[0] = FCFAConvert[CreateFeynAmp[diags], IncomingMomenta->{p1,p2},
 
 
 FCClearScalarProducts[];
-SetMandelstam[s, t, u, p1, p2, -k1, -k2, SMP["m_mu"]^2, SMP["m_mu"]^2,
-	SMP["m_u"]^2, SMP["m_u"]^2];
+SetMandelstam[s, t, u, p1, p2, -k1, -k2, SMP["m_mu"], SMP["m_mu"],
+	SMP["m_u"], SMP["m_u"]];
 
 
 (* ::Section:: *)


### PR DESCRIPTION
As described in https://feyncalc.github.io/FeynCalcBook/ref/SetMandelstam.html, the arguments are SetMandelstam[s, t, u, p1, p2, p3, p4, m1, m2, m3, m4]; these masses should not have been squared. These are the only occurrences of /SetMandelstam.*\^/ in the repo.