### PR TITLE
Fix the stale cache problem

### DIFF
--- a/FeynCalc/Shared/CacheManagement.m
+++ b/FeynCalc/Shared/CacheManagement.m
@@ -49,9 +49,6 @@ End[]
 Begin["`CacheManagement`Private`"];
 
 
-SetAttributes[cachedToString, HoldAll];
-
-
 whiteListNames = {
 	ExpandScalarProduct,
 	PairContract,
@@ -114,7 +111,7 @@ FCClearCache[All]:=
 
 
 cachedToString[x_] :=
-	cachedToString[x] = ToString[x];
+	cachedToString[Verbatim[x]] = ToString[x];
 
 
 FCPrint[1,"CacheManagement.m loaded"];


### PR DESCRIPTION
This is to fix the issue #151 .

A concern is that this will cause `FCUseCache[]` to actually cache the dependency indefinitely until `FCClearCache[]` is called manually.
This might cause a new memory overhead when dependency is updated frequently, especially so since `cachedToString[]` does not employ `MemSet[]`.

Test did run slightly slower.
[test-69324b9.txt](https://github.com/FeynCalc/feyncalc/files/7938398/test-69324b9.txt)
[test-ee27a8f.txt](https://github.com/FeynCalc/feyncalc/files/7938399/test-ee27a8f.txt)

Besides, I am curious if caching `ToString[]` is beneficial, since I would expect it is supposed to be merely a conversion.

